### PR TITLE
add ts-nocheck to start of generated TS guest binding files

### DIFF
--- a/crates/gen-guest-ts/src/lib.rs
+++ b/crates/gen-guest-ts/src/lib.rs
@@ -381,6 +381,8 @@ impl JavaScriptGenerator for TypeScript {
 
 impl Generate for TypeScript {
     fn to_file(&mut self) -> (std::path::PathBuf, String) {
+        let ts_nocheck = format!("// @ts-nocheck\n");
+
         let result_ty = self
             .interface
             .functions
@@ -438,7 +440,7 @@ impl Generate for TypeScript {
             .collect();
 
         let mut contents = format!(
-            "{result_ty}{serde_utils}{deserializers}{serializers}\n{typedefs}\n{functions}"
+            "{ts_nocheck}{result_ty}{serde_utils}{deserializers}{serializers}\n{typedefs}\n{functions}"
         );
 
         if self.opts.prettier {

--- a/crates/gen-guest-ts/tests/chars.ts
+++ b/crates/gen-guest-ts/tests/chars.ts
@@ -1,3 +1,4 @@
+// @ts-nocheck
 class Deserializer {
     source
     offset

--- a/crates/gen-guest-ts/tests/conventions.ts
+++ b/crates/gen-guest-ts/tests/conventions.ts
@@ -1,3 +1,4 @@
+// @ts-nocheck
 class Deserializer {
     source
     offset

--- a/crates/gen-guest-ts/tests/empty.ts
+++ b/crates/gen-guest-ts/tests/empty.ts
@@ -1,3 +1,4 @@
+// @ts-nocheck
 class Deserializer {
     source
     offset

--- a/crates/gen-guest-ts/tests/flegs.ts
+++ b/crates/gen-guest-ts/tests/flegs.ts
@@ -1,3 +1,4 @@
+// @ts-nocheck
 class Deserializer {
     source
     offset

--- a/crates/gen-guest-ts/tests/floats.ts
+++ b/crates/gen-guest-ts/tests/floats.ts
@@ -1,3 +1,4 @@
+// @ts-nocheck
 class Deserializer {
     source
     offset

--- a/crates/gen-guest-ts/tests/integers.ts
+++ b/crates/gen-guest-ts/tests/integers.ts
@@ -1,3 +1,4 @@
+// @ts-nocheck
 class Deserializer {
     source
     offset

--- a/crates/gen-guest-ts/tests/lists.ts
+++ b/crates/gen-guest-ts/tests/lists.ts
@@ -1,3 +1,4 @@
+// @ts-nocheck
 class Deserializer {
     source
     offset

--- a/crates/gen-guest-ts/tests/many-arguments.ts
+++ b/crates/gen-guest-ts/tests/many-arguments.ts
@@ -1,3 +1,4 @@
+// @ts-nocheck
 class Deserializer {
     source
     offset

--- a/crates/gen-guest-ts/tests/multi-return.ts
+++ b/crates/gen-guest-ts/tests/multi-return.ts
@@ -1,3 +1,4 @@
+// @ts-nocheck
 class Deserializer {
     source
     offset

--- a/crates/gen-guest-ts/tests/records.ts
+++ b/crates/gen-guest-ts/tests/records.ts
@@ -1,3 +1,4 @@
+// @ts-nocheck
 class Deserializer {
     source
     offset

--- a/crates/gen-guest-ts/tests/resources.ts
+++ b/crates/gen-guest-ts/tests/resources.ts
@@ -1,3 +1,4 @@
+// @ts-nocheck
 class Deserializer {
     source
     offset

--- a/crates/gen-guest-ts/tests/simple-functions.ts
+++ b/crates/gen-guest-ts/tests/simple-functions.ts
@@ -1,3 +1,4 @@
+// @ts-nocheck
 class Deserializer {
     source
     offset

--- a/crates/gen-guest-ts/tests/simple-lists.ts
+++ b/crates/gen-guest-ts/tests/simple-lists.ts
@@ -1,3 +1,4 @@
+// @ts-nocheck
 class Deserializer {
     source
     offset

--- a/crates/gen-guest-ts/tests/small-anonymous.ts
+++ b/crates/gen-guest-ts/tests/small-anonymous.ts
@@ -1,3 +1,4 @@
+// @ts-nocheck
 export type Result<T, E> = { tag: 'ok', val: T } | { tag: 'err', val: E };
 class Deserializer {
     source

--- a/crates/gen-guest-ts/tests/strings.ts
+++ b/crates/gen-guest-ts/tests/strings.ts
@@ -1,3 +1,4 @@
+// @ts-nocheck
 class Deserializer {
     source
     offset

--- a/crates/gen-guest-ts/tests/unions.ts
+++ b/crates/gen-guest-ts/tests/unions.ts
@@ -1,3 +1,4 @@
+// @ts-nocheck
 class Deserializer {
     source
     offset

--- a/crates/gen-guest-ts/tests/variants.ts
+++ b/crates/gen-guest-ts/tests/variants.ts
@@ -1,3 +1,4 @@
+// @ts-nocheck
 export type Result<T, E> = { tag: 'ok', val: T } | { tag: 'err', val: E };
 class Deserializer {
     source


### PR DESCRIPTION
resolves #140
Adds `// @ts-nocheck` to generated TS guest bindings.
If `strict` is set in the TS compiler options, prod builds will fail because they check for strictness and the generated files don't have types.
With this flag set, these autogenerated files get ignored without specifying these files in the settings.

Just a suggestion happy to adapt the code if you have suggestions.