### PR TITLE
feat: bump msrv to 1.70

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -27,7 +27,7 @@ jobs:
     strategy:
       fail-fast: false
       matrix:
-        rust: [nightly, stable, 1.65.0]
+        rust: [nightly, stable, 1.70.0]
     timeout-minutes: 45
     steps:
       - uses: actions/checkout@v3
@@ -44,7 +44,7 @@ jobs:
           RUSTFLAGS: ${{matrix.rustflags}} ${{env.RUSTFLAGS}}
 
   msrv:
-    name: Rust 1.65.0
+    name: Rust 1.70.0
     needs: pre_ci
     if: needs.pre_ci.outputs.continue
     runs-on: ubuntu-latest
@@ -55,7 +55,7 @@ jobs:
         run: |
           sudo apt-get update
           sudo apt-get install -y webkit2gtk-4.0 libgtk-3-dev
-      - uses: dtolnay/rust-toolchain@1.65.0
+      - uses: dtolnay/rust-toolchain@1.70.0
       - uses: Swatinem/rust-cache@v2
       - run: cargo check --workspace --tests
 

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -27,7 +27,7 @@ jobs:
     strategy:
       fail-fast: false
       matrix:
-        rust: [nightly, stable, 1.64.0]
+        rust: [nightly, stable, 1.65.0]
     timeout-minutes: 45
     steps:
       - uses: actions/checkout@v3
@@ -44,7 +44,7 @@ jobs:
           RUSTFLAGS: ${{matrix.rustflags}} ${{env.RUSTFLAGS}}
 
   msrv:
-    name: Rust 1.64.0
+    name: Rust 1.65.0
     needs: pre_ci
     if: needs.pre_ci.outputs.continue
     runs-on: ubuntu-latest
@@ -55,7 +55,7 @@ jobs:
         run: |
           sudo apt-get update
           sudo apt-get install -y webkit2gtk-4.0 libgtk-3-dev
-      - uses: dtolnay/rust-toolchain@1.64.0
+      - uses: dtolnay/rust-toolchain@1.65.0
       - uses: Swatinem/rust-cache@v2
       - run: cargo check --workspace --tests
 

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -13,7 +13,7 @@ resolver = "2"
 authors = ["Jonas Kruckenberg <iterpre@protonmail.com>"]
 version = "0.2.0"
 edition = "2021"
-rust-version = "1.65"
+rust-version = "1.70"
 
 [workspace.dependencies]
 thiserror = "1.0.47"

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -13,7 +13,7 @@ resolver = "2"
 authors = ["Jonas Kruckenberg <iterpre@protonmail.com>"]
 version = "0.2.0"
 edition = "2021"
-rust-version = "1.64"
+rust-version = "1.65"
 
 [workspace.dependencies]
 thiserror = "1.0.47"


### PR DESCRIPTION
`addr2line@v0.21.0` needs Rust >= 1.65. [See](https://github.com/tauri-apps/tauri-bindgen/actions/runs/5950852790/job/16139483355?pr=177)
`clap@v4.4.0` needs Rust >= 1.70. [See](https://github.com/tauri-apps/tauri-bindgen/actions/runs/5975377761/job/16211222952?pr=178)