### PR TITLE
feat: add resource type

### DIFF
--- a/crates/core/src/lib.rs
+++ b/crates/core/src/lib.rs
@@ -73,7 +73,10 @@ pub struct TypeInfos {
 
 impl TypeInfos {
     #[must_use]
-    pub fn collect_from_functions(typedefs: &TypeDefArena, functions: &[Function]) -> Self {
+    pub fn collect_from_functions<'a>(
+        typedefs: &TypeDefArena,
+        functions: impl Iterator<Item = &'a Function>,
+    ) -> Self {
         let mut this = Self::default();
 
         for func in functions {

--- a/crates/gen-guest-js/src/lib.rs
+++ b/crates/gen-guest-js/src/lib.rs
@@ -111,14 +111,13 @@ export async function {ident} ({params}) {{
                     .join(";\n");
 
                 format!(
-                    r#"
-{docs}
+                    r#"{docs}
 async {ident} ({params}) {{
-const out = []
-serializeU32(out, this.#id);
-{serialize_params}
+    const out = []
+    serializeU32(out, this.#id);
+    {serialize_params}
 
-await fetch('ipc://localhost/{mod_ident}::resource::{resource_ident}/{ident}', {{ method: "POST", body: Uint8Array.from(out), headers: {{ 'Content-Type': 'application/octet-stream' }} }}){deserialize_result}
+    await fetch('ipc://localhost/{mod_ident}::resource::{resource_ident}/{ident}', {{ method: "POST", body: Uint8Array.from(out), headers: {{ 'Content-Type': 'application/octet-stream' }} }}){deserialize_result}
 }}
 "#
                 )

--- a/crates/gen-guest-js/src/lib.rs
+++ b/crates/gen-guest-js/src/lib.rs
@@ -23,7 +23,22 @@ pub struct Builder {
 
 impl GeneratorBuilder for Builder {
     fn build(self, interface: Interface) -> Box<dyn Generate> {
-        let infos = TypeInfos::collect_from_functions(&interface.typedefs, &interface.functions);
+        let methods = interface
+            .typedefs
+            .iter()
+            .filter_map(|(_, typedef)| {
+                if let TypeDefKind::Resource(methods) = &typedef.kind {
+                    Some(methods.iter())
+                } else {
+                    None
+                }
+            })
+            .flatten();
+
+        let infos = TypeInfos::collect_from_functions(
+            &interface.typedefs,
+            interface.functions.iter().chain(methods),
+        );
 
         let serde_utils =
             SerdeUtils::collect_from_functions(&interface.typedefs, &interface.functions);

--- a/crates/gen-guest-js/tests/lists.js
+++ b/crates/gen-guest-js/tests/lists.js
@@ -335,15 +335,18 @@ serializeS64(out, val.c4)
 }function serializeOtherVariant(out, val) {
     if (val.A) {
     serializeU32(out, 0);
-    return 
+    
+    return
 }
 if (val.B) {
     serializeU32(out, 1);
-    return serializeU32(out, val.B)
+    serializeU32(out, val.B)
+    return
 }
 if (val.C) {
     serializeU32(out, 2);
-    return serializeString(out, val.C)
+    serializeString(out, val.C)
+    return
 }
 
 
@@ -351,19 +354,23 @@ if (val.C) {
 }function serializeSomeVariant(out, val) {
     if (val.A) {
     serializeU32(out, 0);
-    return serializeString(out, val.A)
+    serializeString(out, val.A)
+    return
 }
 if (val.B) {
     serializeU32(out, 1);
-    return 
+    
+    return
 }
 if (val.C) {
     serializeU32(out, 2);
-    return serializeU32(out, val.C)
+    serializeU32(out, val.C)
+    return
 }
 if (val.D) {
     serializeU32(out, 3);
-    return serializeList(out, (out, v) => serializeOtherVariant(out, v), val.D)
+    serializeList(out, (out, v) => serializeOtherVariant(out, v), val.D)
+    return
 }
 
 

--- a/crates/gen-guest-js/tests/resources.js
+++ b/crates/gen-guest-js/tests/resources.js
@@ -116,39 +116,36 @@ export async function constructorB () {
 
 export class A {
             #id;
-            
-/**
+            /**
 */
 async f1 () {
-const out = []
-serializeU32(out, this.#id);
+    const out = []
+    serializeU32(out, this.#id);
+    
 
-
-await fetch('ipc://localhost/resources::resource::a/f1', { method: "POST", body: Uint8Array.from(out), headers: { 'Content-Type': 'application/octet-stream' } })
+    await fetch('ipc://localhost/resources::resource::a/f1', { method: "POST", body: Uint8Array.from(out), headers: { 'Content-Type': 'application/octet-stream' } })
 }
-
 /**
 * @param {number} a 
 */
 async f2 (a) {
-const out = []
-serializeU32(out, this.#id);
-serializeU32(out, a)
+    const out = []
+    serializeU32(out, this.#id);
+    serializeU32(out, a)
 
-await fetch('ipc://localhost/resources::resource::a/f2', { method: "POST", body: Uint8Array.from(out), headers: { 'Content-Type': 'application/octet-stream' } })
+    await fetch('ipc://localhost/resources::resource::a/f2', { method: "POST", body: Uint8Array.from(out), headers: { 'Content-Type': 'application/octet-stream' } })
 }
-
 /**
 * @param {number} a 
 * @param {number} b 
 */
 async f3 (a, b) {
-const out = []
-serializeU32(out, this.#id);
-serializeU32(out, a);
+    const out = []
+    serializeU32(out, this.#id);
+    serializeU32(out, a);
 serializeU32(out, b)
 
-await fetch('ipc://localhost/resources::resource::a/f3', { method: "POST", body: Uint8Array.from(out), headers: { 'Content-Type': 'application/octet-stream' } })
+    await fetch('ipc://localhost/resources::resource::a/f3', { method: "POST", body: Uint8Array.from(out), headers: { 'Content-Type': 'application/octet-stream' } })
 }
 
             static deserialize(de) {
@@ -159,16 +156,15 @@ await fetch('ipc://localhost/resources::resource::a/f3', { method: "POST", body:
         }
 export class B {
             #id;
-            
-/**
+            /**
 * @returns {Promise<A>} 
 */
 async f1 () {
-const out = []
-serializeU32(out, this.#id);
+    const out = []
+    serializeU32(out, this.#id);
+    
 
-
-await fetch('ipc://localhost/resources::resource::b/f1', { method: "POST", body: Uint8Array.from(out), headers: { 'Content-Type': 'application/octet-stream' } })
+    await fetch('ipc://localhost/resources::resource::b/f1', { method: "POST", body: Uint8Array.from(out), headers: { 'Content-Type': 'application/octet-stream' } })
         .then(r => r.arrayBuffer())
         .then(bytes => {
             const de = new Deserializer(new Uint8Array(bytes))
@@ -176,17 +172,16 @@ await fetch('ipc://localhost/resources::resource::b/f1', { method: "POST", body:
             return A.deserialize(de)
         })
 }
-
 /**
 * @param {A} x 
 * @returns {Promise<Result<number, _>>} 
 */
 async f2 (x) {
-const out = []
-serializeU32(out, this.#id);
-x.serialize(out)
+    const out = []
+    serializeU32(out, this.#id);
+    x.serialize(out)
 
-await fetch('ipc://localhost/resources::resource::b/f2', { method: "POST", body: Uint8Array.from(out), headers: { 'Content-Type': 'application/octet-stream' } })
+    await fetch('ipc://localhost/resources::resource::b/f2', { method: "POST", body: Uint8Array.from(out), headers: { 'Content-Type': 'application/octet-stream' } })
         .then(r => r.arrayBuffer())
         .then(bytes => {
             const de = new Deserializer(new Uint8Array(bytes))
@@ -194,17 +189,16 @@ await fetch('ipc://localhost/resources::resource::b/f2', { method: "POST", body:
             return deserializeResult(de, (de) => deserializeU32(de), () => {})
         })
 }
-
 /**
 * @param {A[] | null} x 
 * @returns {Promise<Result<A, _>>} 
 */
 async f3 (x) {
-const out = []
-serializeU32(out, this.#id);
-serializeOption(out, (out, v) => serializeList(out, (out, v) => v.serialize(out), v), x)
+    const out = []
+    serializeU32(out, this.#id);
+    serializeOption(out, (out, v) => serializeList(out, (out, v) => v.serialize(out), v), x)
 
-await fetch('ipc://localhost/resources::resource::b/f3', { method: "POST", body: Uint8Array.from(out), headers: { 'Content-Type': 'application/octet-stream' } })
+    await fetch('ipc://localhost/resources::resource::b/f3', { method: "POST", body: Uint8Array.from(out), headers: { 'Content-Type': 'application/octet-stream' } })
         .then(r => r.arrayBuffer())
         .then(bytes => {
             const de = new Deserializer(new Uint8Array(bytes))

--- a/crates/gen-guest-js/tests/resources.js
+++ b/crates/gen-guest-js/tests/resources.js
@@ -17,6 +17,68 @@ class Deserializer {
         return out
     }
 }
+// function varint_max(bits) {
+//   const BITS_PER_BYTE = 8;
+//   const BITS_PER_VARINT_BYTE = 7;
+
+//   const roundup_bits = bits + (BITS_PER_BYTE - 1);
+
+//   return Math.floor(roundup_bits / BITS_PER_VARINT_BYTE);
+// }
+
+const varint_max = {
+  16: 3,
+  32: 5,
+  64: 10,
+  128: 19
+}
+function max_of_last_byte(type) {
+  let extra_bits = type % 7;
+  return (1 << extra_bits) - 1;
+}
+
+function de_varint(de, bits) {
+  let out = 0;
+
+  for (let i = 0; i < varint_max[bits]; i++) {
+    const val = de.pop();
+    const carry = val & 0x7F;
+    out |= carry << (7 * i);
+
+    if ((val & 0x80) === 0) {
+      if (i === varint_max[bits] - 1 && val > max_of_last_byte(bits)) {
+        throw new Error('deserialize bad variant')
+      } else {
+        return out
+      }
+    }
+  }
+
+  throw new Error('deserialize bad variant')
+}
+
+function de_varint_big(de, bits) {
+  let out = 0n;
+
+  for (let i = 0; i < varint_max[bits]; i++) {
+    const val = de.pop();
+    const carry = BigInt(val) & 0x7Fn;
+    out |= carry << (7n * BigInt(i));
+
+    if ((val & 0x80) === 0) {
+      if (i === varint_max[bits] - 1 && val > max_of_last_byte(bits)) {
+        throw new Error('deserialize bad variant')
+      } else {
+        return out
+      }
+    }
+  }
+
+  throw new Error('deserialize bad variant')
+}
+function deserializeU32(de) {
+    return de_varint(de, 32)
+}
 
 
 /**
@@ -52,18 +114,28 @@ export async function constructorB () {
 }
 
 
-class A {
+export class A {
             #id;
             
 /**
 */
 async f1 () {
+const out = []
+serializeU32(out, this.#id);
+
+
+await fetch('ipc://localhost/resources::resource::a/f1', { method: "POST", body: Uint8Array.from(out), headers: { 'Content-Type': 'application/octet-stream' } })
 }
 
 /**
 * @param {number} a 
 */
 async f2 (a) {
+const out = []
+serializeU32(out, this.#id);
+serializeU32(out, a)
+
+await fetch('ipc://localhost/resources::resource::a/f2', { method: "POST", body: Uint8Array.from(out), headers: { 'Content-Type': 'application/octet-stream' } })
 }
 
 /**
@@ -71,21 +143,38 @@ async f2 (a) {
 * @param {number} b 
 */
 async f3 (a, b) {
+const out = []
+serializeU32(out, this.#id);
+serializeU32(out, a);
+serializeU32(out, b)
+
+await fetch('ipc://localhost/resources::resource::a/f3', { method: "POST", body: Uint8Array.from(out), headers: { 'Content-Type': 'application/octet-stream' } })
 }
 
-            deserialize(de) {
+            static deserialize(de) {
     const self = new A();
-    self.#id = deserializeU64(de);
+    self.#id = deserializeU32(de);
     return self
 }
         }
-class B {
+export class B {
             #id;
             
 /**
 * @returns {Promise<A>} 
 */
 async f1 () {
+const out = []
+serializeU32(out, this.#id);
+
+
+await fetch('ipc://localhost/resources::resource::b/f1', { method: "POST", body: Uint8Array.from(out), headers: { 'Content-Type': 'application/octet-stream' } })
+        .then(r => r.arrayBuffer())
+        .then(bytes => {
+            const de = new Deserializer(new Uint8Array(bytes))
+
+            return A.deserialize(de)
+        })
 }
 
 /**
@@ -93,6 +182,17 @@ async f1 () {
 * @returns {Promise<Result<number, _>>} 
 */
 async f2 (x) {
+const out = []
+serializeU32(out, this.#id);
+x.serialize(out)
+
+await fetch('ipc://localhost/resources::resource::b/f2', { method: "POST", body: Uint8Array.from(out), headers: { 'Content-Type': 'application/octet-stream' } })
+        .then(r => r.arrayBuffer())
+        .then(bytes => {
+            const de = new Deserializer(new Uint8Array(bytes))
+
+            return deserializeResult(de, (de) => deserializeU32(de), () => {})
+        })
 }
 
 /**
@@ -100,11 +200,22 @@ async f2 (x) {
 * @returns {Promise<Result<A, _>>} 
 */
 async f3 (x) {
+const out = []
+serializeU32(out, this.#id);
+serializeOption(out, (out, v) => serializeList(out, (out, v) => v.serialize(out), v), x)
+
+await fetch('ipc://localhost/resources::resource::b/f3', { method: "POST", body: Uint8Array.from(out), headers: { 'Content-Type': 'application/octet-stream' } })
+        .then(r => r.arrayBuffer())
+        .then(bytes => {
+            const de = new Deserializer(new Uint8Array(bytes))
+
+            return deserializeResult(de, (de) => A.deserialize(de), () => {})
+        })
 }
 
-            deserialize(de) {
+            static deserialize(de) {
     const self = new B();
-    self.#id = deserializeU64(de);
+    self.#id = deserializeU32(de);
     return self
 }
         }

--- a/crates/gen-guest-js/tests/variants.js
+++ b/crates/gen-guest-js/tests/variants.js
@@ -431,31 +431,38 @@ case 1:
 }function serializeV1(out, val) {
     if (val.A) {
     serializeU32(out, 0);
-    return 
+    
+    return
 }
 if (val.B) {
     serializeU32(out, 1);
-    return serializeU1(out, val.B)
+    serializeU1(out, val.B)
+    return
 }
 if (val.C) {
     serializeU32(out, 2);
-    return serializeE1(out, val.C)
+    serializeE1(out, val.C)
+    return
 }
 if (val.D) {
     serializeU32(out, 3);
-    return serializeString(out, val.D)
+    serializeString(out, val.D)
+    return
 }
 if (val.E) {
     serializeU32(out, 4);
-    return serializeEmpty(out, val.E)
+    serializeEmpty(out, val.E)
+    return
 }
 if (val.F) {
     serializeU32(out, 5);
-    return 
+    
+    return
 }
 if (val.G) {
     serializeU32(out, 6);
-    return serializeU32(out, val.G)
+    serializeU32(out, val.G)
+    return
 }
 
 
@@ -463,11 +470,13 @@ if (val.G) {
 }function serializeCasts1(out, val) {
     if (val.A) {
     serializeU32(out, 0);
-    return serializeS32(out, val.A)
+    serializeS32(out, val.A)
+    return
 }
 if (val.B) {
     serializeU32(out, 1);
-    return serializeF32(out, val.B)
+    serializeF32(out, val.B)
+    return
 }
 
 
@@ -475,11 +484,13 @@ if (val.B) {
 }function serializeCasts2(out, val) {
     if (val.A) {
     serializeU32(out, 0);
-    return serializeF64(out, val.A)
+    serializeF64(out, val.A)
+    return
 }
 if (val.B) {
     serializeU32(out, 1);
-    return serializeF32(out, val.B)
+    serializeF32(out, val.B)
+    return
 }
 
 
@@ -487,11 +498,13 @@ if (val.B) {
 }function serializeCasts3(out, val) {
     if (val.A) {
     serializeU32(out, 0);
-    return serializeF64(out, val.A)
+    serializeF64(out, val.A)
+    return
 }
 if (val.B) {
     serializeU32(out, 1);
-    return serializeU64(out, val.B)
+    serializeU64(out, val.B)
+    return
 }
 
 
@@ -499,11 +512,13 @@ if (val.B) {
 }function serializeCasts4(out, val) {
     if (val.A) {
     serializeU32(out, 0);
-    return serializeU32(out, val.A)
+    serializeU32(out, val.A)
+    return
 }
 if (val.B) {
     serializeU32(out, 1);
-    return serializeS64(out, val.B)
+    serializeS64(out, val.B)
+    return
 }
 
 
@@ -511,11 +526,13 @@ if (val.B) {
 }function serializeCasts5(out, val) {
     if (val.A) {
     serializeU32(out, 0);
-    return serializeF32(out, val.A)
+    serializeF32(out, val.A)
+    return
 }
 if (val.B) {
     serializeU32(out, 1);
-    return serializeS64(out, val.B)
+    serializeS64(out, val.B)
+    return
 }
 
 
@@ -523,11 +540,13 @@ if (val.B) {
 }function serializeCasts6(out, val) {
     if (val.A) {
     serializeU32(out, 0);
-    return {serializeF32(out, val.A[0]);serializeU32(out, val.A[1])}
+    {serializeF32(out, val.A[0]);serializeU32(out, val.A[1])}
+    return
 }
 if (val.B) {
     serializeU32(out, 1);
-    return {serializeU32(out, val.B[0]);serializeU32(out, val.B[1])}
+    {serializeU32(out, val.B[0]);serializeU32(out, val.B[1])}
+    return
 }
 
 

--- a/crates/gen-guest-rust/tests/resources.rs
+++ b/crates/gen-guest-rust/tests/resources.rs
@@ -3,34 +3,42 @@
 pub mod resources {
     use ::tauri_bindgen_guest_rust::serde;
     use ::tauri_bindgen_guest_rust::bitflags;
-    #[derive(serde::Deserialize)]
-    pub struct A {
-        id: u64,
-    }
+    #[derive(serde::Serialize, serde::Deserialize)]
+    pub struct A(u32);
     impl A {
         pub async fn f1(&self) {
-            todo!()
+            ::tauri_bindgen_guest_rust::invoke("resources;::resource::A", "f1", &())
+                .await
+                .unwrap()
         }
         pub async fn f2(&self, a: u32) {
-            todo!()
+            ::tauri_bindgen_guest_rust::invoke("resources;::resource::A", "f2", &(a))
+                .await
+                .unwrap()
         }
         pub async fn f3(&self, a: u32, b: u32) {
-            todo!()
+            ::tauri_bindgen_guest_rust::invoke("resources;::resource::A", "f3", &(a, b))
+                .await
+                .unwrap()
         }
     }
     #[derive(serde::Deserialize)]
-    pub struct B {
-        id: u64,
-    }
+    pub struct B(u32);
     impl B {
         pub async fn f1(&self) -> A {
-            todo!()
+            ::tauri_bindgen_guest_rust::invoke("resources;::resource::B", "f1", &())
+                .await
+                .unwrap()
         }
         pub async fn f2(&self, x: A) -> Result<u32, ()> {
-            todo!()
+            ::tauri_bindgen_guest_rust::invoke("resources;::resource::B", "f2", &(x))
+                .await
+                .unwrap()
         }
         pub async fn f3(&self, x: Option<&'_ [A]>) -> Result<A, ()> {
-            todo!()
+            ::tauri_bindgen_guest_rust::invoke("resources;::resource::B", "f3", &(x))
+                .await
+                .unwrap()
         }
     }
     pub async fn constructor_a() -> A {

--- a/crates/gen-guest-rust/tests/resources.rs
+++ b/crates/gen-guest-rust/tests/resources.rs
@@ -7,17 +7,29 @@ pub mod resources {
     pub struct A(u32);
     impl A {
         pub async fn f1(&self) {
-            ::tauri_bindgen_guest_rust::invoke("resources;::resource::A", "f1", &())
+            ::tauri_bindgen_guest_rust::invoke(
+                    "resources::resource::a",
+                    "f1",
+                    &(self.0,),
+                )
                 .await
                 .unwrap()
         }
         pub async fn f2(&self, a: u32) {
-            ::tauri_bindgen_guest_rust::invoke("resources;::resource::A", "f2", &(a))
+            ::tauri_bindgen_guest_rust::invoke(
+                    "resources::resource::a",
+                    "f2",
+                    &(self.0, a),
+                )
                 .await
                 .unwrap()
         }
         pub async fn f3(&self, a: u32, b: u32) {
-            ::tauri_bindgen_guest_rust::invoke("resources;::resource::A", "f3", &(a, b))
+            ::tauri_bindgen_guest_rust::invoke(
+                    "resources::resource::a",
+                    "f3",
+                    &(self.0, a, b),
+                )
                 .await
                 .unwrap()
         }
@@ -26,17 +38,29 @@ pub mod resources {
     pub struct B(u32);
     impl B {
         pub async fn f1(&self) -> A {
-            ::tauri_bindgen_guest_rust::invoke("resources;::resource::B", "f1", &())
+            ::tauri_bindgen_guest_rust::invoke(
+                    "resources::resource::b",
+                    "f1",
+                    &(self.0,),
+                )
                 .await
                 .unwrap()
         }
         pub async fn f2(&self, x: A) -> Result<u32, ()> {
-            ::tauri_bindgen_guest_rust::invoke("resources;::resource::B", "f2", &(x))
+            ::tauri_bindgen_guest_rust::invoke(
+                    "resources::resource::b",
+                    "f2",
+                    &(self.0, x),
+                )
                 .await
                 .unwrap()
         }
         pub async fn f3(&self, x: Option<&'_ [A]>) -> Result<A, ()> {
-            ::tauri_bindgen_guest_rust::invoke("resources;::resource::B", "f3", &(x))
+            ::tauri_bindgen_guest_rust::invoke(
+                    "resources::resource::b",
+                    "f3",
+                    &(self.0, x),
+                )
                 .await
                 .unwrap()
         }

--- a/crates/gen-guest-ts/src/lib.rs
+++ b/crates/gen-guest-ts/src/lib.rs
@@ -314,8 +314,7 @@ export async function {ident} ({params}) : {result} {{
                 let result = func
                     .result
                     .as_ref()
-                    .map(|result| self.print_function_result(result))
-                    .unwrap_or("void".to_string());
+                    .map_or("void".to_string(), |result| self.print_function_result(result));
 
                 let deserialize_result = func
                     .result

--- a/crates/gen-guest-ts/src/lib.rs
+++ b/crates/gen-guest-ts/src/lib.rs
@@ -31,7 +31,22 @@ pub struct Builder {
 
 impl GeneratorBuilder for Builder {
     fn build(self, interface: Interface) -> Box<dyn Generate> {
-        let infos = TypeInfos::collect_from_functions(&interface.typedefs, &interface.functions);
+        let methods = interface
+            .typedefs
+            .iter()
+            .filter_map(|(_, typedef)| {
+                if let TypeDefKind::Resource(methods) = &typedef.kind {
+                    Some(methods.iter())
+                } else {
+                    None
+                }
+            })
+            .flatten();
+
+        let infos = TypeInfos::collect_from_functions(
+            &interface.typedefs,
+            interface.functions.iter().chain(methods),
+        );
 
         let serde_utils =
             SerdeUtils::collect_from_functions(&interface.typedefs, &interface.functions);

--- a/crates/gen-guest-ts/src/lib.rs
+++ b/crates/gen-guest-ts/src/lib.rs
@@ -189,7 +189,9 @@ export async function {ident} ({params}) : {result} {{
             TypeDefKind::Variant(cases) => self.print_variant(&docs, ident, cases),
             TypeDefKind::Enum(cases) => self.print_enum(&docs, ident, cases),
             TypeDefKind::Union(cases) => self.print_union(&docs, ident, cases),
-            TypeDefKind::Resource(functions) => self.print_resource(&docs, ident, functions),
+            TypeDefKind::Resource(functions) => {
+                self.print_resource(&self.interface.ident, &docs, ident, functions)
+            }
         }
     }
 
@@ -293,12 +295,19 @@ export async function {ident} ({params}) : {result} {{
         format!("{docs}\nexport type {ident} = {cases};\n")
     }
 
-    fn print_resource(&self, docs: &str, ident: &str, functions: &[Function]) -> String {
+    fn print_resource(
+        &self,
+        mod_ident: &str,
+        docs: &str,
+        ident: &str,
+        functions: &[Function],
+    ) -> String {
         let functions: String = functions
             .iter()
             .map(|func| {
                 let docs = print_docs(&func.docs);
-
+                let mod_ident = mod_ident.to_snake_case();
+                let resource_ident = ident.to_snake_case();
                 let ident = func.ident.to_lower_camel_case();
 
                 let params = self.print_function_params(&func.params);
@@ -306,12 +315,29 @@ export async function {ident} ({params}) : {result} {{
                     .result
                     .as_ref()
                     .map(|result| self.print_function_result(result))
+                    .unwrap_or("void".to_string());
+
+                let deserialize_result = func
+                    .result
+                    .as_ref()
+                    .map(|res| self.print_deserialize_function_result(res))
                     .unwrap_or_default();
 
+                let serialize_params = func
+                    .params
+                    .iter()
+                    .map(|(ident, ty)| self.print_serialize_ty(&ident.to_lower_camel_case(), ty))
+                    .collect::<Vec<_>>()
+                    .join(";\n");
+
                 format!(
-                    r#"
-{docs}
-async {ident} ({params}) {result} {{
+                    r#"{docs}
+async {ident} ({params}) : {result} {{
+    const out = []
+    serializeU32(out, this.#id);
+    {serialize_params}
+
+    await fetch('ipc://localhost/{mod_ident}::resource::{resource_ident}/{ident}', {{ method: "POST", body: Uint8Array.from(out), headers: {{ 'Content-Type': 'application/octet-stream' }} }}){deserialize_result}
 }}
 "#
                 )
@@ -319,7 +345,7 @@ async {ident} ({params}) {result} {{
             .collect();
 
         format!(
-            "{docs}\nclass {ident} {{
+            "{docs}\nexport class {ident} {{
     #id: number;
 
     {functions}

--- a/crates/gen-guest-ts/tests/lists.ts
+++ b/crates/gen-guest-ts/tests/lists.ts
@@ -336,15 +336,18 @@ serializeS64(out, val.c4)
 }function serializeOtherVariant(out, val) {
     if (val.A) {
     serializeU32(out, 0);
-    return 
+    
+    return
 }
 if (val.B) {
     serializeU32(out, 1);
-    return serializeU32(out, val.B)
+    serializeU32(out, val.B)
+    return
 }
 if (val.C) {
     serializeU32(out, 2);
-    return serializeString(out, val.C)
+    serializeString(out, val.C)
+    return
 }
 
 
@@ -352,19 +355,23 @@ if (val.C) {
 }function serializeSomeVariant(out, val) {
     if (val.A) {
     serializeU32(out, 0);
-    return serializeString(out, val.A)
+    serializeString(out, val.A)
+    return
 }
 if (val.B) {
     serializeU32(out, 1);
-    return 
+    
+    return
 }
 if (val.C) {
     serializeU32(out, 2);
-    return serializeU32(out, val.C)
+    serializeU32(out, val.C)
+    return
 }
 if (val.D) {
     serializeU32(out, 3);
-    return serializeList(out, (out, v) => serializeOtherVariant(out, v), val.D)
+    serializeList(out, (out, v) => serializeOtherVariant(out, v), val.D)
+    return
 }
 
 

--- a/crates/gen-guest-ts/tests/resources.ts
+++ b/crates/gen-guest-ts/tests/resources.ts
@@ -18,6 +18,68 @@ class Deserializer {
         return out
     }
 }
+// function varint_max(bits) {
+//   const BITS_PER_BYTE = 8;
+//   const BITS_PER_VARINT_BYTE = 7;
+
+//   const roundup_bits = bits + (BITS_PER_BYTE - 1);
+
+//   return Math.floor(roundup_bits / BITS_PER_VARINT_BYTE);
+// }
+
+const varint_max = {
+  16: 3,
+  32: 5,
+  64: 10,
+  128: 19
+}
+function max_of_last_byte(type) {
+  let extra_bits = type % 7;
+  return (1 << extra_bits) - 1;
+}
+
+function de_varint(de, bits) {
+  let out = 0;
+
+  for (let i = 0; i < varint_max[bits]; i++) {
+    const val = de.pop();
+    const carry = val & 0x7F;
+    out |= carry << (7 * i);
+
+    if ((val & 0x80) === 0) {
+      if (i === varint_max[bits] - 1 && val > max_of_last_byte(bits)) {
+        throw new Error('deserialize bad variant')
+      } else {
+        return out
+      }
+    }
+  }
+
+  throw new Error('deserialize bad variant')
+}
+
+function de_varint_big(de, bits) {
+  let out = 0n;
+
+  for (let i = 0; i < varint_max[bits]; i++) {
+    const val = de.pop();
+    const carry = BigInt(val) & 0x7Fn;
+    out |= carry << (7n * BigInt(i));
+
+    if ((val & 0x80) === 0) {
+      if (i === varint_max[bits] - 1 && val > max_of_last_byte(bits)) {
+        throw new Error('deserialize bad variant')
+      } else {
+        return out
+      }
+    }
+  }
+
+  throw new Error('deserialize bad variant')
+}
+function deserializeU32(de) {
+    return de_varint(de, 32)
+}
 
 
 class A {

--- a/crates/gen-guest-ts/tests/resources.ts
+++ b/crates/gen-guest-ts/tests/resources.ts
@@ -82,37 +82,80 @@ function deserializeU32(de) {
 }
 
 
-class A {
+export class A {
     #id: number;
 
     
+async f1 () : void {
+    const out = []
+    serializeU32(out, this.#id);
+    
 
-async f1 ()  {
+    await fetch('ipc://localhost/resources::resource::a/f1', { method: "POST", body: Uint8Array.from(out), headers: { 'Content-Type': 'application/octet-stream' } })
 }
 
+async f2 (a: number) : void {
+    const out = []
+    serializeU32(out, this.#id);
+    serializeU32(out, a)
 
-async f2 (a: number)  {
+    await fetch('ipc://localhost/resources::resource::a/f2', { method: "POST", body: Uint8Array.from(out), headers: { 'Content-Type': 'application/octet-stream' } })
 }
 
+async f3 (a: number, b: number) : void {
+    const out = []
+    serializeU32(out, this.#id);
+    serializeU32(out, a);
+serializeU32(out, b)
 
-async f3 (a: number, b: number)  {
+    await fetch('ipc://localhost/resources::resource::a/f3', { method: "POST", body: Uint8Array.from(out), headers: { 'Content-Type': 'application/octet-stream' } })
 }
 
 }
-class B {
+export class B {
     #id: number;
 
     
+async f1 () : Promise<A> {
+    const out = []
+    serializeU32(out, this.#id);
+    
 
-async f1 () Promise<A> {
+    await fetch('ipc://localhost/resources::resource::b/f1', { method: "POST", body: Uint8Array.from(out), headers: { 'Content-Type': 'application/octet-stream' } })
+        .then(r => r.arrayBuffer())
+        .then(bytes => {
+            const de = new Deserializer(new Uint8Array(bytes))
+
+            return A.deserialize(de)
+        })
 }
 
+async f2 (x: A) : Promise<Result<number, null>> {
+    const out = []
+    serializeU32(out, this.#id);
+    x.serialize(out)
 
-async f2 (x: A) Promise<Result<number, null>> {
+    await fetch('ipc://localhost/resources::resource::b/f2', { method: "POST", body: Uint8Array.from(out), headers: { 'Content-Type': 'application/octet-stream' } })
+        .then(r => r.arrayBuffer())
+        .then(bytes => {
+            const de = new Deserializer(new Uint8Array(bytes))
+
+            return deserializeResult(de, (de) => deserializeU32(de), () => {})
+        })
 }
 
+async f3 (x: A[] | null) : Promise<Result<A, null>> {
+    const out = []
+    serializeU32(out, this.#id);
+    serializeOption(out, (out, v) => serializeList(out, (out, v) => v.serialize(out), v), x)
 
-async f3 (x: A[] | null) Promise<Result<A, null>> {
+    await fetch('ipc://localhost/resources::resource::b/f3', { method: "POST", body: Uint8Array.from(out), headers: { 'Content-Type': 'application/octet-stream' } })
+        .then(r => r.arrayBuffer())
+        .then(bytes => {
+            const de = new Deserializer(new Uint8Array(bytes))
+
+            return deserializeResult(de, (de) => A.deserialize(de), () => {})
+        })
 }
 
 }

--- a/crates/gen-guest-ts/tests/variants.ts
+++ b/crates/gen-guest-ts/tests/variants.ts
@@ -1,23 +1,23 @@
 // @ts-nocheck
 export type Result<T, E> = { tag: 'ok', val: T } | { tag: 'err', val: E };
 class Deserializer {
-    source
-    offset
-    
-    constructor(bytes) {
-        this.source = bytes
-        this.offset = 0
-    }
+  source
+  offset
 
-    pop() {
-        return this.source[this.offset++]
-    }
+  constructor(bytes) {
+    this.source = bytes
+    this.offset = 0
+  }
 
-    try_take_n(len) {
-        const out = this.source.slice(this.offset, this.offset + len)
-        this.offset += len
-        return out
-    }
+  pop() {
+    return this.source[this.offset++]
+  }
+
+  try_take_n(len) {
+    const out = this.source.slice(this.offset, this.offset + len)
+    this.offset += len
+    return out
+  }
 }
 // function varint_max(bits) {
 //   const BITS_PER_BYTE = 8;
@@ -79,31 +79,31 @@ function de_varint_big(de, bits) {
   throw new Error('deserialize bad variant')
 }
 function deserializeBool(de) {
-    const val = de.pop();
+  const val = de.pop();
 
-    return val != 0
+  return val != 0
 }
 function deserializeU8(de) {
-    return de.pop()
+  return de.pop()
 }
 function deserializeU32(de) {
-    return de_varint(de, 32)
+  return de_varint(de, 32)
 }
 function deserializeU64(de) {
   return de_varint_big(de, 64)
 }
 function deserializeS8(de) {
-    const buf = new ArrayBuffer(1);
-    const view = new DataView(buf);
+  const buf = new ArrayBuffer(1);
+  const view = new DataView(buf);
 
-    buf[0] = view.setUint8(0, de.pop());
+  buf[0] = view.setUint8(0, de.pop());
 
-    return view.getInt8(0);
+  return view.getInt8(0);
 }
 function deserializeS32(de) {
-    const n = de_varint(de, 32)
+  const n = de_varint(de, 32)
 
-    return Number(((n >> 1) & 0xFFFFFFFF) ^ (-((n & 0b1) & 0xFFFFFFFF)))
+  return Number(((n >> 1) & 0xFFFFFFFF) ^ (-((n & 0b1) & 0xFFFFFFFF)))
 }
 function deserializeS64(de) {
   const n = de_varint_big(de, 64)
@@ -111,62 +111,62 @@ function deserializeS64(de) {
   return ((n >> 1n) & 0xFFFFFFFFFFFFFFFFn) ^ (-((n & 0b1n) & 0xFFFFFFFFFFFFFFFFn))
 }
 function deserializeF32(de) {
-    const bytes = de.try_take_n(4);
+  const bytes = de.try_take_n(4);
 
-    const buf = new ArrayBuffer(4);
-    const view = new DataView(buf);
+  const buf = new ArrayBuffer(4);
+  const view = new DataView(buf);
 
-    bytes.forEach((v, i) => view.setUint8(i, v));
+  bytes.forEach((v, i) => view.setUint8(i, v));
 
-    return view.getFloat32(0, true);
+  return view.getFloat32(0, true);
 }
 function deserializeF64(de) {
-    const bytes = de.try_take_n(8);
+  const bytes = de.try_take_n(8);
 
-    const buf = new ArrayBuffer(8);
-    const view = new DataView(buf);
+  const buf = new ArrayBuffer(8);
+  const view = new DataView(buf);
 
-    bytes.forEach((v, i) => view.setUint8(i, v));
+  bytes.forEach((v, i) => view.setUint8(i, v));
 
-    return view.getFloat64(0, true);
+  return view.getFloat64(0, true);
 }
 function deserializeString(de) {
-    const sz = deserializeU64(de);
+  const sz = deserializeU64(de);
 
-    let bytes = de.try_take_n(Number(sz));
+  let bytes = de.try_take_n(Number(sz));
 
-    return __text_decoder.decode(bytes);
+  return __text_decoder.decode(bytes);
 }
 function deserializeBytes(de) {
-    const sz = deserializeU64(de);
+  const sz = deserializeU64(de);
 
-    let bytes = de.try_take_n(Number(sz));
+  let bytes = de.try_take_n(Number(sz));
 
-    return bytes;
+  return bytes;
 }
 function deserializeOption(de, inner) {
-    const tag = de.pop()
+  const tag = de.pop()
 
-    switch (tag) {
-        case 0:
-            return null
-        case 1: 
-            return inner(de)
-        default:
-            throw new Error(`Deserialize bad option ${tag}`)
-    }
+  switch (tag) {
+    case 0:
+      return null
+    case 1:
+      return inner(de)
+    default:
+      throw new Error(`Deserialize bad option ${tag}`)
+  }
 }
 function deserializeResult(de, ok, err) {
-    const tag = de.pop()
+  const tag = de.pop()
 
-    switch (tag) {
-        case 0:
-            return { tag: 'ok', val: ok(de) }
-        case 1: 
-            return { tag: 'err', val: err(de) }
-        default:
-            throw new Error(`Deserialize bad result ${tag}`)
-    }
+  switch (tag) {
+    case 0:
+      return { tag: 'ok', val: ok(de) }
+    case 1:
+      return { tag: 'err', val: err(de) }
+    default:
+      throw new Error(`Deserialize bad result ${tag}`)
+  }
 }
 function ser_varint(out, bits, val) {
   let buf = []
@@ -204,351 +204,370 @@ function ser_varint_big(out, bits, val) {
   out.push(...buf)
 }
 function serializeBool(out, val) {
-    out.push(val === true ? 1 : 0)
+  out.push(val === true ? 1 : 0)
 }
 function serializeU8(out, val) {
-    return out.push(val)
+  return out.push(val)
 }
 function serializeU32(out, val) {
-    return ser_varint(out, 32, val)
+  return ser_varint(out, 32, val)
 }
 function serializeU64(out, val) {
   return ser_varint_big(out, 64, BigInt(val))
 }
 function serializeS8(out, val) {
-    out.push(val)
+  out.push(val)
 }
 function serializeS32(out, val) {
-    ser_varint(out, 32, (val << 1) ^ (val >> 31))
+  ser_varint(out, 32, (val << 1) ^ (val >> 31))
 }
 function serializeS64(out, val) {
   val = BigInt(val)
   ser_varint_big(out, 64, (val << 1n) ^ (val >> 63n))
 }
 function serializeF32(out, val) {
-    const buf = new ArrayBuffer(4);
-    const view = new DataView(buf);
+  const buf = new ArrayBuffer(4);
+  const view = new DataView(buf);
 
-    view.setFloat32(0, val, true);
+  view.setFloat32(0, val, true);
 
-    out.push(...new Uint8Array(buf))
+  out.push(...new Uint8Array(buf))
 }
 function serializeF64(out, val) {
-    const buf = new ArrayBuffer(8);
-    const view = new DataView(buf);
+  const buf = new ArrayBuffer(8);
+  const view = new DataView(buf);
 
-    view.setFloat64(0, val, true);
+  view.setFloat64(0, val, true);
 
-    out.push(...new Uint8Array(buf))
+  out.push(...new Uint8Array(buf))
 }
 function serializeString(out, val) {
-    serializeU64(out, val.length);
+  serializeU64(out, val.length);
 
-    out.push(...__text_encoder.encode(val))
+  out.push(...__text_encoder.encode(val))
 }
 function serializeBytes(out, val) {
-    serializeU64(out, val.length);
-    out.push(...val)
+  serializeU64(out, val.length);
+  out.push(...val)
 }
 function serializeOption(out, inner, val) {
-    serializeU8(out, !!val ? 1 : 0)
-    if (val) {
-        inner(out, val)
-    }
+  serializeU8(out, !!val ? 1 : 0)
+  if (val) {
+    inner(out, val)
+  }
 }
 function serializeResult(out, ok, err, val) {
-    if (val.Ok) {
-        serializeU8(out, 0);
-        return ok(out, val.Ok);
-    }
+  if (val.Ok) {
+    serializeU8(out, 0);
+    return ok(out, val.Ok);
+  }
 
-    if (val.Err) {
-        serializeU8(out, 1);
-        return err(out, val.Err);
-    }
+  if (val.Err) {
+    serializeU8(out, 1);
+    return err(out, val.Err);
+  }
 
-    throw new Error(`Serialize bad result ${val}`);
+  throw new Error(`Serialize bad result ${val}`);
 }
 const __text_decoder = new TextDecoder('utf-8');
 const __text_encoder = new TextEncoder();
 function deserializeE1(de) {
-    const tag = deserializeU32(de)
+  const tag = deserializeU32(de)
 
-    switch (tag) {
-        case 0:
-    return "A"
+  switch (tag) {
+    case 0:
+      return "A"
 
-        default:
-            throw new Error(`unknown enum case ${tag}`)
-    }
-}function deserializeU1(de) {
-    const tag = deserializeU32(de)
+    default:
+      throw new Error(`unknown enum case ${tag}`)
+  }
+} function deserializeU1(de) {
+  const tag = deserializeU32(de)
 
-    switch (tag) {
-        case 0:
-    return { U32: deserializeU32(de) }
-case 1:
-    return { F32: deserializeF32(de) }
+  switch (tag) {
+    case 0:
+      return { U32: deserializeU32(de) }
+    case 1:
+      return { F32: deserializeF32(de) }
 
-        default:
-            throw new Error(`unknown union case ${tag}`)
-    }
-}function deserializeEmpty(de) {
-    return {
-        
-    }
-}function deserializeV1(de) {
-    const tag = deserializeU32(de)
+    default:
+      throw new Error(`unknown union case ${tag}`)
+  }
+} function deserializeEmpty(de) {
+  return {
 
-    switch (tag) {
-        case 0:
-    return { A: null }
-case 1:
-    return { B: deserializeU1(de) }
-case 2:
-    return { C: deserializeE1(de) }
-case 3:
-    return { D: deserializeString(de) }
-case 4:
-    return { E: deserializeEmpty(de) }
-case 5:
-    return { F: null }
-case 6:
-    return { G: deserializeU32(de) }
+  }
+} function deserializeV1(de) {
+  const tag = deserializeU32(de)
 
-        default:
-            throw new Error(`unknown variant case ${tag}`)
-    }
-}function deserializeCasts1(de) {
-    const tag = deserializeU32(de)
+  switch (tag) {
+    case 0:
+      return { A: null }
+    case 1:
+      return { B: deserializeU1(de) }
+    case 2:
+      return { C: deserializeE1(de) }
+    case 3:
+      return { D: deserializeString(de) }
+    case 4:
+      return { E: deserializeEmpty(de) }
+    case 5:
+      return { F: null }
+    case 6:
+      return { G: deserializeU32(de) }
 
-    switch (tag) {
-        case 0:
-    return { A: deserializeS32(de) }
-case 1:
-    return { B: deserializeF32(de) }
+    default:
+      throw new Error(`unknown variant case ${tag}`)
+  }
+} function deserializeCasts1(de) {
+  const tag = deserializeU32(de)
 
-        default:
-            throw new Error(`unknown variant case ${tag}`)
-    }
-}function deserializeCasts2(de) {
-    const tag = deserializeU32(de)
+  switch (tag) {
+    case 0:
+      return { A: deserializeS32(de) }
+    case 1:
+      return { B: deserializeF32(de) }
 
-    switch (tag) {
-        case 0:
-    return { A: deserializeF64(de) }
-case 1:
-    return { B: deserializeF32(de) }
+    default:
+      throw new Error(`unknown variant case ${tag}`)
+  }
+} function deserializeCasts2(de) {
+  const tag = deserializeU32(de)
 
-        default:
-            throw new Error(`unknown variant case ${tag}`)
-    }
-}function deserializeCasts3(de) {
-    const tag = deserializeU32(de)
+  switch (tag) {
+    case 0:
+      return { A: deserializeF64(de) }
+    case 1:
+      return { B: deserializeF32(de) }
 
-    switch (tag) {
-        case 0:
-    return { A: deserializeF64(de) }
-case 1:
-    return { B: deserializeU64(de) }
+    default:
+      throw new Error(`unknown variant case ${tag}`)
+  }
+} function deserializeCasts3(de) {
+  const tag = deserializeU32(de)
 
-        default:
-            throw new Error(`unknown variant case ${tag}`)
-    }
-}function deserializeCasts4(de) {
-    const tag = deserializeU32(de)
+  switch (tag) {
+    case 0:
+      return { A: deserializeF64(de) }
+    case 1:
+      return { B: deserializeU64(de) }
 
-    switch (tag) {
-        case 0:
-    return { A: deserializeU32(de) }
-case 1:
-    return { B: deserializeS64(de) }
+    default:
+      throw new Error(`unknown variant case ${tag}`)
+  }
+} function deserializeCasts4(de) {
+  const tag = deserializeU32(de)
 
-        default:
-            throw new Error(`unknown variant case ${tag}`)
-    }
-}function deserializeCasts5(de) {
-    const tag = deserializeU32(de)
+  switch (tag) {
+    case 0:
+      return { A: deserializeU32(de) }
+    case 1:
+      return { B: deserializeS64(de) }
 
-    switch (tag) {
-        case 0:
-    return { A: deserializeF32(de) }
-case 1:
-    return { B: deserializeS64(de) }
+    default:
+      throw new Error(`unknown variant case ${tag}`)
+  }
+} function deserializeCasts5(de) {
+  const tag = deserializeU32(de)
 
-        default:
-            throw new Error(`unknown variant case ${tag}`)
-    }
-}function deserializeCasts6(de) {
-    const tag = deserializeU32(de)
+  switch (tag) {
+    case 0:
+      return { A: deserializeF32(de) }
+    case 1:
+      return { B: deserializeS64(de) }
 
-    switch (tag) {
-        case 0:
-    return { A: [deserializeF32(de), deserializeU32(de)] }
-case 1:
-    return { B: [deserializeU32(de), deserializeU32(de)] }
+    default:
+      throw new Error(`unknown variant case ${tag}`)
+  }
+} function deserializeCasts6(de) {
+  const tag = deserializeU32(de)
 
-        default:
-            throw new Error(`unknown variant case ${tag}`)
-    }
-}function deserializeMyErrno(de) {
-    const tag = deserializeU32(de)
+  switch (tag) {
+    case 0:
+      return { A: [deserializeF32(de), deserializeU32(de)] }
+    case 1:
+      return { B: [deserializeU32(de), deserializeU32(de)] }
 
-    switch (tag) {
-        case 0:
-    return "Bad1"
-case 1:
-    return "Bad2"
+    default:
+      throw new Error(`unknown variant case ${tag}`)
+  }
+} function deserializeMyErrno(de) {
+  const tag = deserializeU32(de)
 
-        default:
-            throw new Error(`unknown enum case ${tag}`)
-    }
-}function deserializeIsClone(de) {
-    return {
-        v1: deserializeV1(de)
-    }
-}function serializeE1(out, val) {
-    switch (val) {
-        case "A":
-    serializeU32(out, 0)
-    return
+  switch (tag) {
+    case 0:
+      return "Bad1"
+    case 1:
+      return "Bad2"
 
-        default:
-            throw new Error("unknown enum case")
-    }
-}function serializeU1(out, val) {
-    if (val.U32) {
+    default:
+      throw new Error(`unknown enum case ${tag}`)
+  }
+} function deserializeIsClone(de) {
+  return {
+    v1: deserializeV1(de)
+  }
+} function serializeE1(out, val) {
+  switch (val) {
+    case "A":
+      serializeU32(out, 0)
+      return
+
+    default:
+      throw new Error("unknown enum case")
+  }
+} function serializeU1(out, val) {
+  if (val.U32) {
     serializeU32(out, 0);
     return serializeU32(out, val.U32)
-}
-                if (val.F32) {
+  }
+  if (val.F32) {
     serializeU32(out, 1);
     return serializeF32(out, val.F32)
-}
-                
+  }
 
-    throw new Error("unknown union case")
-}function serializeEmpty(out, val) {
-    
-}function serializeV1(out, val) {
-    if (val.A) {
+
+  throw new Error("unknown union case")
+} function serializeEmpty(out, val) {
+
+} function serializeV1(out, val) {
+  if (val.A) {
     serializeU32(out, 0);
-    return 
-}
-if (val.B) {
+
+    return
+  }
+  if (val.B) {
     serializeU32(out, 1);
-    return serializeU1(out, val.B)
-}
-if (val.C) {
+    serializeU1(out, val.B)
+    return
+  }
+  if (val.C) {
     serializeU32(out, 2);
-    return serializeE1(out, val.C)
-}
-if (val.D) {
+    serializeE1(out, val.C)
+    return
+  }
+  if (val.D) {
     serializeU32(out, 3);
-    return serializeString(out, val.D)
-}
-if (val.E) {
+    serializeString(out, val.D)
+    return
+  }
+  if (val.E) {
     serializeU32(out, 4);
-    return serializeEmpty(out, val.E)
-}
-if (val.F) {
+    serializeEmpty(out, val.E)
+    return
+  }
+  if (val.F) {
     serializeU32(out, 5);
-    return 
-}
-if (val.G) {
+
+    return
+  }
+  if (val.G) {
     serializeU32(out, 6);
-    return serializeU32(out, val.G)
-}
+    serializeU32(out, val.G)
+    return
+  }
 
 
-    throw new Error("unknown variant case")
-}function serializeCasts1(out, val) {
-    if (val.A) {
+  throw new Error("unknown variant case")
+} function serializeCasts1(out, val) {
+  if (val.A) {
     serializeU32(out, 0);
-    return serializeS32(out, val.A)
-}
-if (val.B) {
+    serializeS32(out, val.A)
+    return
+  }
+  if (val.B) {
     serializeU32(out, 1);
-    return serializeF32(out, val.B)
-}
+    serializeF32(out, val.B)
+    return
+  }
 
 
-    throw new Error("unknown variant case")
-}function serializeCasts2(out, val) {
-    if (val.A) {
+  throw new Error("unknown variant case")
+} function serializeCasts2(out, val) {
+  if (val.A) {
     serializeU32(out, 0);
-    return serializeF64(out, val.A)
-}
-if (val.B) {
+    serializeF64(out, val.A)
+    return
+  }
+  if (val.B) {
     serializeU32(out, 1);
-    return serializeF32(out, val.B)
-}
+    serializeF32(out, val.B)
+    return
+  }
 
 
-    throw new Error("unknown variant case")
-}function serializeCasts3(out, val) {
-    if (val.A) {
+  throw new Error("unknown variant case")
+} function serializeCasts3(out, val) {
+  if (val.A) {
     serializeU32(out, 0);
-    return serializeF64(out, val.A)
-}
-if (val.B) {
+    serializeF64(out, val.A)
+    return
+  }
+  if (val.B) {
     serializeU32(out, 1);
-    return serializeU64(out, val.B)
-}
+    serializeU64(out, val.B)
+    return
+  }
 
 
-    throw new Error("unknown variant case")
-}function serializeCasts4(out, val) {
-    if (val.A) {
+  throw new Error("unknown variant case")
+} function serializeCasts4(out, val) {
+  if (val.A) {
     serializeU32(out, 0);
-    return serializeU32(out, val.A)
-}
-if (val.B) {
+    serializeU32(out, val.A)
+    return
+  }
+  if (val.B) {
     serializeU32(out, 1);
-    return serializeS64(out, val.B)
-}
+    serializeS64(out, val.B)
+    return
+  }
 
 
-    throw new Error("unknown variant case")
-}function serializeCasts5(out, val) {
-    if (val.A) {
+  throw new Error("unknown variant case")
+} function serializeCasts5(out, val) {
+  if (val.A) {
     serializeU32(out, 0);
-    return serializeF32(out, val.A)
-}
-if (val.B) {
+    serializeF32(out, val.A)
+    return
+  }
+  if (val.B) {
     serializeU32(out, 1);
-    return serializeS64(out, val.B)
-}
+    serializeS64(out, val.B)
+    return
+  }
 
 
-    throw new Error("unknown variant case")
-}function serializeCasts6(out, val) {
-    if (val.A) {
+  throw new Error("unknown variant case")
+} function serializeCasts6(out, val) {
+  if (val.A) {
     serializeU32(out, 0);
-    return {serializeF32(out, val.A[0]);serializeU32(out, val.A[1])}
-}
-if (val.B) {
+    { serializeF32(out, val.A[0]); serializeU32(out, val.A[1]) }
+    return
+  }
+  if (val.B) {
     serializeU32(out, 1);
-    return {serializeU32(out, val.B[0]);serializeU32(out, val.B[1])}
+    { serializeU32(out, val.B[0]); serializeU32(out, val.B[1]) }
+    return
+  }
+
+
+  throw new Error("unknown variant case")
+} function serializeIsClone(out, val) {
+  serializeV1(out, val.v1)
 }
 
-
-    throw new Error("unknown variant case")
-}function serializeIsClone(out, val) {
-    serializeV1(out, val.v1)
+export enum E1 {
+  A,
 }
 
-export enum E1 { 
-A,
- }
+export type U1 =
+  number
+  |
+  number
+  ;
 
-export type U1 = 
-number
- | 
-number
-;
-
-export interface Empty {  }
+export interface Empty { }
 
 export interface V1A { tag: 0 }
 
@@ -565,387 +584,386 @@ export interface V1F { tag: 5 }
 export interface V1G { tag: 6, value: number }
 
 
-export type V1 = 
-V1A | 
-V1B | 
-V1C | 
-V1D | 
-V1E | 
-V1F | 
-V1G
+export type V1 =
+  V1A |
+  V1B |
+  V1C |
+  V1D |
+  V1E |
+  V1F |
+  V1G
 
 export interface Casts1A { tag: 0, value: number }
 
 export interface Casts1B { tag: 1, value: number }
 
 
-export type Casts1 = 
-Casts1A | 
-Casts1B
+export type Casts1 =
+  Casts1A |
+  Casts1B
 
 export interface Casts2A { tag: 0, value: number }
 
 export interface Casts2B { tag: 1, value: number }
 
 
-export type Casts2 = 
-Casts2A | 
-Casts2B
+export type Casts2 =
+  Casts2A |
+  Casts2B
 
 export interface Casts3A { tag: 0, value: number }
 
 export interface Casts3B { tag: 1, value: bigint }
 
 
-export type Casts3 = 
-Casts3A | 
-Casts3B
+export type Casts3 =
+  Casts3A |
+  Casts3B
 
 export interface Casts4A { tag: 0, value: number }
 
 export interface Casts4B { tag: 1, value: bigint }
 
 
-export type Casts4 = 
-Casts4A | 
-Casts4B
+export type Casts4 =
+  Casts4A |
+  Casts4B
 
 export interface Casts5A { tag: 0, value: number }
 
 export interface Casts5B { tag: 1, value: bigint }
 
 
-export type Casts5 = 
-Casts5A | 
-Casts5B
+export type Casts5 =
+  Casts5A |
+  Casts5B
 
 export interface Casts6A { tag: 0, value: [number, number] }
 
 export interface Casts6B { tag: 1, value: [number, number] }
 
 
-export type Casts6 = 
-Casts6A | 
-Casts6B
+export type Casts6 =
+  Casts6A |
+  Casts6B
 
-export enum MyErrno { 
-Bad1,
+export enum MyErrno {
+  Bad1,
 
-Bad2,
- }
-
-export interface IsClone { 
-v1: V1,
- }
-
-
-
-export async function e1Arg (x: E1) : Promise<void> {
-    const out = []
-    serializeE1(out, x)
-
-     fetch('ipc://localhost/variants/e1_arg', { method: "POST", body: Uint8Array.from(out) }) 
+  Bad2,
 }
-        
 
-export async function e1Result () : Promise<E1> {
-    const out = []
-    
-
-    return fetch('ipc://localhost/variants/e1_result', { method: "POST", body: Uint8Array.from(out) })
-        .then(r => r.arrayBuffer())
-        .then(bytes => {
-            const de = new Deserializer(new Uint8Array(bytes))
-
-            return deserializeE1(de)
-        }) as Promise<E1>
+export interface IsClone {
+  v1: V1,
 }
-        
 
-export async function u1Arg (x: U1) : Promise<void> {
-    const out = []
-    serializeU1(out, x)
 
-     fetch('ipc://localhost/variants/u1_arg', { method: "POST", body: Uint8Array.from(out) }) 
+
+export async function e1Arg(x: E1): Promise<void> {
+  const out = []
+  serializeE1(out, x)
+
+  fetch('ipc://localhost/variants/e1_arg', { method: "POST", body: Uint8Array.from(out) })
 }
-        
 
-export async function u1Result () : Promise<U1> {
-    const out = []
-    
 
-    return fetch('ipc://localhost/variants/u1_result', { method: "POST", body: Uint8Array.from(out) })
-        .then(r => r.arrayBuffer())
-        .then(bytes => {
-            const de = new Deserializer(new Uint8Array(bytes))
+export async function e1Result(): Promise<E1> {
+  const out = []
 
-            return deserializeU1(de)
-        }) as Promise<U1>
+
+  return fetch('ipc://localhost/variants/e1_result', { method: "POST", body: Uint8Array.from(out) })
+    .then(r => r.arrayBuffer())
+    .then(bytes => {
+      const de = new Deserializer(new Uint8Array(bytes))
+
+      return deserializeE1(de)
+    }) as Promise<E1>
 }
-        
 
-export async function v1Arg (x: V1) : Promise<void> {
-    const out = []
-    serializeV1(out, x)
 
-     fetch('ipc://localhost/variants/v1_arg', { method: "POST", body: Uint8Array.from(out) }) 
+export async function u1Arg(x: U1): Promise<void> {
+  const out = []
+  serializeU1(out, x)
+
+  fetch('ipc://localhost/variants/u1_arg', { method: "POST", body: Uint8Array.from(out) })
 }
-        
 
-export async function v1Result () : Promise<V1> {
-    const out = []
-    
 
-    return fetch('ipc://localhost/variants/v1_result', { method: "POST", body: Uint8Array.from(out) })
-        .then(r => r.arrayBuffer())
-        .then(bytes => {
-            const de = new Deserializer(new Uint8Array(bytes))
+export async function u1Result(): Promise<U1> {
+  const out = []
 
-            return deserializeV1(de)
-        }) as Promise<V1>
+
+  return fetch('ipc://localhost/variants/u1_result', { method: "POST", body: Uint8Array.from(out) })
+    .then(r => r.arrayBuffer())
+    .then(bytes => {
+      const de = new Deserializer(new Uint8Array(bytes))
+
+      return deserializeU1(de)
+    }) as Promise<U1>
 }
-        
 
-export async function boolArg (x: boolean) : Promise<void> {
-    const out = []
-    serializeBool(out, x)
 
-     fetch('ipc://localhost/variants/bool_arg', { method: "POST", body: Uint8Array.from(out) }) 
+export async function v1Arg(x: V1): Promise<void> {
+  const out = []
+  serializeV1(out, x)
+
+  fetch('ipc://localhost/variants/v1_arg', { method: "POST", body: Uint8Array.from(out) })
 }
-        
 
-export async function boolResult () : Promise<boolean> {
-    const out = []
-    
 
-    return fetch('ipc://localhost/variants/bool_result', { method: "POST", body: Uint8Array.from(out) })
-        .then(r => r.arrayBuffer())
-        .then(bytes => {
-            const de = new Deserializer(new Uint8Array(bytes))
+export async function v1Result(): Promise<V1> {
+  const out = []
 
-            return deserializeBool(de)
-        }) as Promise<boolean>
+
+  return fetch('ipc://localhost/variants/v1_result', { method: "POST", body: Uint8Array.from(out) })
+    .then(r => r.arrayBuffer())
+    .then(bytes => {
+      const de = new Deserializer(new Uint8Array(bytes))
+
+      return deserializeV1(de)
+    }) as Promise<V1>
 }
-        
 
-export async function optionArg (a: boolean | null, b: [] | null, c: number | null, d: E1 | null, e: number | null, f: U1 | null, g: boolean | null | null) : Promise<void> {
-    const out = []
-    serializeOption(out, (out, v) => serializeBool(out, v), a);
-serializeOption(out, (out, v) => {}, b);
-serializeOption(out, (out, v) => serializeU32(out, v), c);
-serializeOption(out, (out, v) => serializeE1(out, v), d);
-serializeOption(out, (out, v) => serializeF32(out, v), e);
-serializeOption(out, (out, v) => serializeU1(out, v), f);
-serializeOption(out, (out, v) => serializeOption(out, (out, v) => serializeBool(out, v), v), g)
 
-     fetch('ipc://localhost/variants/option_arg', { method: "POST", body: Uint8Array.from(out) }) 
+export async function boolArg(x: boolean): Promise<void> {
+  const out = []
+  serializeBool(out, x)
+
+  fetch('ipc://localhost/variants/bool_arg', { method: "POST", body: Uint8Array.from(out) })
 }
-        
 
-export async function optionResult () : Promise<[boolean | null, [] | null, number | null, E1 | null, number | null, U1 | null, boolean | null | null]> {
-    const out = []
-    
 
-    return fetch('ipc://localhost/variants/option_result', { method: "POST", body: Uint8Array.from(out) })
-        .then(r => r.arrayBuffer())
-        .then(bytes => {
-            const de = new Deserializer(new Uint8Array(bytes))
+export async function boolResult(): Promise<boolean> {
+  const out = []
 
-            return [deserializeOption(de, (de) => deserializeBool(de)), deserializeOption(de, (de) => []), deserializeOption(de, (de) => deserializeU32(de)), deserializeOption(de, (de) => deserializeE1(de)), deserializeOption(de, (de) => deserializeF32(de)), deserializeOption(de, (de) => deserializeU1(de)), deserializeOption(de, (de) => deserializeOption(de, (de) => deserializeBool(de)))]
-        }) as Promise<[boolean | null, [] | null, number | null, E1 | null, number | null, U1 | null, boolean | null | null]>
+
+  return fetch('ipc://localhost/variants/bool_result', { method: "POST", body: Uint8Array.from(out) })
+    .then(r => r.arrayBuffer())
+    .then(bytes => {
+      const de = new Deserializer(new Uint8Array(bytes))
+
+      return deserializeBool(de)
+    }) as Promise<boolean>
 }
-        
 
-export async function casts (a: Casts1, b: Casts2, c: Casts3, d: Casts4, e: Casts5, f: Casts6) : Promise<[Casts1, Casts2, Casts3, Casts4, Casts5, Casts6]> {
-    const out = []
-    serializeCasts1(out, a);
-serializeCasts2(out, b);
-serializeCasts3(out, c);
-serializeCasts4(out, d);
-serializeCasts5(out, e);
-serializeCasts6(out, f)
 
-    return fetch('ipc://localhost/variants/casts', { method: "POST", body: Uint8Array.from(out) })
-        .then(r => r.arrayBuffer())
-        .then(bytes => {
-            const de = new Deserializer(new Uint8Array(bytes))
+export async function optionArg(a: boolean | null, b: [] | null, c: number | null, d: E1 | null, e: number | null, f: U1 | null, g: boolean | null | null): Promise<void> {
+  const out = []
+  serializeOption(out, (out, v) => serializeBool(out, v), a);
+  serializeOption(out, (out, v) => { }, b);
+  serializeOption(out, (out, v) => serializeU32(out, v), c);
+  serializeOption(out, (out, v) => serializeE1(out, v), d);
+  serializeOption(out, (out, v) => serializeF32(out, v), e);
+  serializeOption(out, (out, v) => serializeU1(out, v), f);
+  serializeOption(out, (out, v) => serializeOption(out, (out, v) => serializeBool(out, v), v), g)
 
-            return [deserializeCasts1(de), deserializeCasts2(de), deserializeCasts3(de), deserializeCasts4(de), deserializeCasts5(de), deserializeCasts6(de)]
-        }) as Promise<[Casts1, Casts2, Casts3, Casts4, Casts5, Casts6]>
+  fetch('ipc://localhost/variants/option_arg', { method: "POST", body: Uint8Array.from(out) })
 }
-        
 
-export async function resultArg (a: Result<null, null>, b: Result<null, E1>, c: Result<E1, null>, d: Result<[], []>, e: Result<number, V1>, f: Result<string, Uint8Array[]>) : Promise<void> {
-    const out = []
-    serializeResult(out, (out, v) => {}, (out, v) => {}, a);
-serializeResult(out, (out, v) => {}, (out, v) => serializeE1(out, v), b);
-serializeResult(out, (out, v) => serializeE1(out, v), (out, v) => {}, c);
-serializeResult(out, (out, v) => {}, (out, v) => {}, d);
-serializeResult(out, (out, v) => serializeU32(out, v), (out, v) => serializeV1(out, v), e);
-serializeResult(out, (out, v) => serializeString(out, v), (out, v) => serializeBytes(out, v), f)
 
-     fetch('ipc://localhost/variants/result_arg', { method: "POST", body: Uint8Array.from(out) }) 
+export async function optionResult(): Promise<[boolean | null, [] | null, number | null, E1 | null, number | null, U1 | null, boolean | null | null]> {
+  const out = []
+
+
+  return fetch('ipc://localhost/variants/option_result', { method: "POST", body: Uint8Array.from(out) })
+    .then(r => r.arrayBuffer())
+    .then(bytes => {
+      const de = new Deserializer(new Uint8Array(bytes))
+
+      return [deserializeOption(de, (de) => deserializeBool(de)), deserializeOption(de, (de) => []), deserializeOption(de, (de) => deserializeU32(de)), deserializeOption(de, (de) => deserializeE1(de)), deserializeOption(de, (de) => deserializeF32(de)), deserializeOption(de, (de) => deserializeU1(de)), deserializeOption(de, (de) => deserializeOption(de, (de) => deserializeBool(de)))]
+    }) as Promise<[boolean | null, [] | null, number | null, E1 | null, number | null, U1 | null, boolean | null | null]>
 }
-        
 
-export async function resultResult () : Promise<[Result<null, null>, Result<null, E1>, Result<E1, null>, Result<[], []>, Result<number, V1>, Result<string, Uint8Array[]>]> {
-    const out = []
-    
 
-    return fetch('ipc://localhost/variants/result_result', { method: "POST", body: Uint8Array.from(out) })
-        .then(r => r.arrayBuffer())
-        .then(bytes => {
-            const de = new Deserializer(new Uint8Array(bytes))
+export async function casts(a: Casts1, b: Casts2, c: Casts3, d: Casts4, e: Casts5, f: Casts6): Promise<[Casts1, Casts2, Casts3, Casts4, Casts5, Casts6]> {
+  const out = []
+  serializeCasts1(out, a);
+  serializeCasts2(out, b);
+  serializeCasts3(out, c);
+  serializeCasts4(out, d);
+  serializeCasts5(out, e);
+  serializeCasts6(out, f)
 
-            return [deserializeResult(de, () => {}, () => {}), deserializeResult(de, () => {}, (de) => deserializeE1(de)), deserializeResult(de, (de) => deserializeE1(de), () => {}), deserializeResult(de, (de) => [], (de) => []), deserializeResult(de, (de) => deserializeU32(de), (de) => deserializeV1(de)), deserializeResult(de, (de) => deserializeString(de), (de) => deserializeBytes(de))]
-        }) as Promise<[Result<null, null>, Result<null, E1>, Result<E1, null>, Result<[], []>, Result<number, V1>, Result<string, Uint8Array[]>]>
+  return fetch('ipc://localhost/variants/casts', { method: "POST", body: Uint8Array.from(out) })
+    .then(r => r.arrayBuffer())
+    .then(bytes => {
+      const de = new Deserializer(new Uint8Array(bytes))
+
+      return [deserializeCasts1(de), deserializeCasts2(de), deserializeCasts3(de), deserializeCasts4(de), deserializeCasts5(de), deserializeCasts6(de)]
+    }) as Promise<[Casts1, Casts2, Casts3, Casts4, Casts5, Casts6]>
 }
-        
 
-export async function returnResultSugar () : Promise<Result<number, MyErrno>> {
-    const out = []
-    
 
-    return fetch('ipc://localhost/variants/return_result_sugar', { method: "POST", body: Uint8Array.from(out) })
-        .then(r => r.arrayBuffer())
-        .then(bytes => {
-            const de = new Deserializer(new Uint8Array(bytes))
+export async function resultArg(a: Result<null, null>, b: Result<null, E1>, c: Result<E1, null>, d: Result<[], []>, e: Result<number, V1>, f: Result<string, Uint8Array[]>): Promise<void> {
+  const out = []
+  serializeResult(out, (out, v) => { }, (out, v) => { }, a);
+  serializeResult(out, (out, v) => { }, (out, v) => serializeE1(out, v), b);
+  serializeResult(out, (out, v) => serializeE1(out, v), (out, v) => { }, c);
+  serializeResult(out, (out, v) => { }, (out, v) => { }, d);
+  serializeResult(out, (out, v) => serializeU32(out, v), (out, v) => serializeV1(out, v), e);
+  serializeResult(out, (out, v) => serializeString(out, v), (out, v) => serializeBytes(out, v), f)
 
-            return deserializeResult(de, (de) => deserializeS32(de), (de) => deserializeMyErrno(de))
-        }) as Promise<Result<number, MyErrno>>
+  fetch('ipc://localhost/variants/result_arg', { method: "POST", body: Uint8Array.from(out) })
 }
-        
 
-export async function returnResultSugar2 () : Promise<Result<null, MyErrno>> {
-    const out = []
-    
 
-    return fetch('ipc://localhost/variants/return_result_sugar2', { method: "POST", body: Uint8Array.from(out) })
-        .then(r => r.arrayBuffer())
-        .then(bytes => {
-            const de = new Deserializer(new Uint8Array(bytes))
+export async function resultResult(): Promise<[Result<null, null>, Result<null, E1>, Result<E1, null>, Result<[], []>, Result<number, V1>, Result<string, Uint8Array[]>]> {
+  const out = []
 
-            return deserializeResult(de, () => {}, (de) => deserializeMyErrno(de))
-        }) as Promise<Result<null, MyErrno>>
+
+  return fetch('ipc://localhost/variants/result_result', { method: "POST", body: Uint8Array.from(out) })
+    .then(r => r.arrayBuffer())
+    .then(bytes => {
+      const de = new Deserializer(new Uint8Array(bytes))
+
+      return [deserializeResult(de, () => { }, () => { }), deserializeResult(de, () => { }, (de) => deserializeE1(de)), deserializeResult(de, (de) => deserializeE1(de), () => { }), deserializeResult(de, (de) => [], (de) => []), deserializeResult(de, (de) => deserializeU32(de), (de) => deserializeV1(de)), deserializeResult(de, (de) => deserializeString(de), (de) => deserializeBytes(de))]
+    }) as Promise<[Result<null, null>, Result<null, E1>, Result<E1, null>, Result<[], []>, Result<number, V1>, Result<string, Uint8Array[]>]>
 }
-        
 
-export async function returnResultSugar3 () : Promise<Result<MyErrno, MyErrno>> {
-    const out = []
-    
 
-    return fetch('ipc://localhost/variants/return_result_sugar3', { method: "POST", body: Uint8Array.from(out) })
-        .then(r => r.arrayBuffer())
-        .then(bytes => {
-            const de = new Deserializer(new Uint8Array(bytes))
+export async function returnResultSugar(): Promise<Result<number, MyErrno>> {
+  const out = []
 
-            return deserializeResult(de, (de) => deserializeMyErrno(de), (de) => deserializeMyErrno(de))
-        }) as Promise<Result<MyErrno, MyErrno>>
+
+  return fetch('ipc://localhost/variants/return_result_sugar', { method: "POST", body: Uint8Array.from(out) })
+    .then(r => r.arrayBuffer())
+    .then(bytes => {
+      const de = new Deserializer(new Uint8Array(bytes))
+
+      return deserializeResult(de, (de) => deserializeS32(de), (de) => deserializeMyErrno(de))
+    }) as Promise<Result<number, MyErrno>>
 }
-        
 
-export async function returnResultSugar4 () : Promise<Result<[number, number], MyErrno>> {
-    const out = []
-    
 
-    return fetch('ipc://localhost/variants/return_result_sugar4', { method: "POST", body: Uint8Array.from(out) })
-        .then(r => r.arrayBuffer())
-        .then(bytes => {
-            const de = new Deserializer(new Uint8Array(bytes))
+export async function returnResultSugar2(): Promise<Result<null, MyErrno>> {
+  const out = []
 
-            return deserializeResult(de, (de) => [deserializeS32(de), deserializeU32(de)], (de) => deserializeMyErrno(de))
-        }) as Promise<Result<[number, number], MyErrno>>
+
+  return fetch('ipc://localhost/variants/return_result_sugar2', { method: "POST", body: Uint8Array.from(out) })
+    .then(r => r.arrayBuffer())
+    .then(bytes => {
+      const de = new Deserializer(new Uint8Array(bytes))
+
+      return deserializeResult(de, () => { }, (de) => deserializeMyErrno(de))
+    }) as Promise<Result<null, MyErrno>>
 }
-        
 
-export async function returnOptionSugar () : Promise<number | null> {
-    const out = []
-    
 
-    return fetch('ipc://localhost/variants/return_option_sugar', { method: "POST", body: Uint8Array.from(out) })
-        .then(r => r.arrayBuffer())
-        .then(bytes => {
-            const de = new Deserializer(new Uint8Array(bytes))
+export async function returnResultSugar3(): Promise<Result<MyErrno, MyErrno>> {
+  const out = []
 
-            return deserializeOption(de, (de) => deserializeS32(de))
-        }) as Promise<number | null>
+
+  return fetch('ipc://localhost/variants/return_result_sugar3', { method: "POST", body: Uint8Array.from(out) })
+    .then(r => r.arrayBuffer())
+    .then(bytes => {
+      const de = new Deserializer(new Uint8Array(bytes))
+
+      return deserializeResult(de, (de) => deserializeMyErrno(de), (de) => deserializeMyErrno(de))
+    }) as Promise<Result<MyErrno, MyErrno>>
 }
-        
 
-export async function returnOptionSugar2 () : Promise<MyErrno | null> {
-    const out = []
-    
 
-    return fetch('ipc://localhost/variants/return_option_sugar2', { method: "POST", body: Uint8Array.from(out) })
-        .then(r => r.arrayBuffer())
-        .then(bytes => {
-            const de = new Deserializer(new Uint8Array(bytes))
+export async function returnResultSugar4(): Promise<Result<[number, number], MyErrno>> {
+  const out = []
 
-            return deserializeOption(de, (de) => deserializeMyErrno(de))
-        }) as Promise<MyErrno | null>
+
+  return fetch('ipc://localhost/variants/return_result_sugar4', { method: "POST", body: Uint8Array.from(out) })
+    .then(r => r.arrayBuffer())
+    .then(bytes => {
+      const de = new Deserializer(new Uint8Array(bytes))
+
+      return deserializeResult(de, (de) => [deserializeS32(de), deserializeU32(de)], (de) => deserializeMyErrno(de))
+    }) as Promise<Result<[number, number], MyErrno>>
 }
-        
 
-export async function resultSimple () : Promise<Result<number, number>> {
-    const out = []
-    
 
-    return fetch('ipc://localhost/variants/result_simple', { method: "POST", body: Uint8Array.from(out) })
-        .then(r => r.arrayBuffer())
-        .then(bytes => {
-            const de = new Deserializer(new Uint8Array(bytes))
+export async function returnOptionSugar(): Promise<number | null> {
+  const out = []
 
-            return deserializeResult(de, (de) => deserializeU32(de), (de) => deserializeS32(de))
-        }) as Promise<Result<number, number>>
+
+  return fetch('ipc://localhost/variants/return_option_sugar', { method: "POST", body: Uint8Array.from(out) })
+    .then(r => r.arrayBuffer())
+    .then(bytes => {
+      const de = new Deserializer(new Uint8Array(bytes))
+
+      return deserializeOption(de, (de) => deserializeS32(de))
+    }) as Promise<number | null>
 }
-        
 
-export async function isCloneArg (a: IsClone) : Promise<void> {
-    const out = []
-    serializeIsClone(out, a)
 
-     fetch('ipc://localhost/variants/is_clone_arg', { method: "POST", body: Uint8Array.from(out) }) 
+export async function returnOptionSugar2(): Promise<MyErrno | null> {
+  const out = []
+
+
+  return fetch('ipc://localhost/variants/return_option_sugar2', { method: "POST", body: Uint8Array.from(out) })
+    .then(r => r.arrayBuffer())
+    .then(bytes => {
+      const de = new Deserializer(new Uint8Array(bytes))
+
+      return deserializeOption(de, (de) => deserializeMyErrno(de))
+    }) as Promise<MyErrno | null>
 }
-        
 
-export async function isCloneReturn () : Promise<IsClone> {
-    const out = []
-    
 
-    return fetch('ipc://localhost/variants/is_clone_return', { method: "POST", body: Uint8Array.from(out) })
-        .then(r => r.arrayBuffer())
-        .then(bytes => {
-            const de = new Deserializer(new Uint8Array(bytes))
+export async function resultSimple(): Promise<Result<number, number>> {
+  const out = []
 
-            return deserializeIsClone(de)
-        }) as Promise<IsClone>
+
+  return fetch('ipc://localhost/variants/result_simple', { method: "POST", body: Uint8Array.from(out) })
+    .then(r => r.arrayBuffer())
+    .then(bytes => {
+      const de = new Deserializer(new Uint8Array(bytes))
+
+      return deserializeResult(de, (de) => deserializeU32(de), (de) => deserializeS32(de))
+    }) as Promise<Result<number, number>>
 }
-        
 
-export async function returnNamedOption () : Promise<number | null> {
-    const out = []
-    
 
-    return fetch('ipc://localhost/variants/return_named_option', { method: "POST", body: Uint8Array.from(out) })
-        .then(r => r.arrayBuffer())
-        .then(bytes => {
-            const de = new Deserializer(new Uint8Array(bytes))
+export async function isCloneArg(a: IsClone): Promise<void> {
+  const out = []
+  serializeIsClone(out, a)
 
-            return deserializeOption(de, (de) => deserializeU8(de))
-        }) as Promise<number | null>
+  fetch('ipc://localhost/variants/is_clone_arg', { method: "POST", body: Uint8Array.from(out) })
 }
-        
 
-export async function returnNamedResult () : Promise<Result<number, MyErrno>> {
-    const out = []
-    
 
-    return fetch('ipc://localhost/variants/return_named_result', { method: "POST", body: Uint8Array.from(out) })
-        .then(r => r.arrayBuffer())
-        .then(bytes => {
-            const de = new Deserializer(new Uint8Array(bytes))
+export async function isCloneReturn(): Promise<IsClone> {
+  const out = []
 
-            return deserializeResult(de, (de) => deserializeU8(de), (de) => deserializeMyErrno(de))
-        }) as Promise<Result<number, MyErrno>>
+
+  return fetch('ipc://localhost/variants/is_clone_return', { method: "POST", body: Uint8Array.from(out) })
+    .then(r => r.arrayBuffer())
+    .then(bytes => {
+      const de = new Deserializer(new Uint8Array(bytes))
+
+      return deserializeIsClone(de)
+    }) as Promise<IsClone>
 }
-        
+
+
+export async function returnNamedOption(): Promise<number | null> {
+  const out = []
+
+
+  return fetch('ipc://localhost/variants/return_named_option', { method: "POST", body: Uint8Array.from(out) })
+    .then(r => r.arrayBuffer())
+    .then(bytes => {
+      const de = new Deserializer(new Uint8Array(bytes))
+
+      return deserializeOption(de, (de) => deserializeU8(de))
+    }) as Promise<number | null>
+}
+
+
+export async function returnNamedResult(): Promise<Result<number, MyErrno>> {
+  const out = []
+
+
+  return fetch('ipc://localhost/variants/return_named_result', { method: "POST", body: Uint8Array.from(out) })
+    .then(r => r.arrayBuffer())
+    .then(bytes => {
+      const de = new Deserializer(new Uint8Array(bytes))
+
+      return deserializeResult(de, (de) => deserializeU8(de), (de) => deserializeMyErrno(de))
+    }) as Promise<Result<number, MyErrno>>
+}

--- a/crates/gen-guest-ts/tests/variants.ts
+++ b/crates/gen-guest-ts/tests/variants.ts
@@ -1,23 +1,23 @@
 // @ts-nocheck
 export type Result<T, E> = { tag: 'ok', val: T } | { tag: 'err', val: E };
 class Deserializer {
-  source
-  offset
+    source
+    offset
+    
+    constructor(bytes) {
+        this.source = bytes
+        this.offset = 0
+    }
 
-  constructor(bytes) {
-    this.source = bytes
-    this.offset = 0
-  }
+    pop() {
+        return this.source[this.offset++]
+    }
 
-  pop() {
-    return this.source[this.offset++]
-  }
-
-  try_take_n(len) {
-    const out = this.source.slice(this.offset, this.offset + len)
-    this.offset += len
-    return out
-  }
+    try_take_n(len) {
+        const out = this.source.slice(this.offset, this.offset + len)
+        this.offset += len
+        return out
+    }
 }
 // function varint_max(bits) {
 //   const BITS_PER_BYTE = 8;
@@ -79,31 +79,31 @@ function de_varint_big(de, bits) {
   throw new Error('deserialize bad variant')
 }
 function deserializeBool(de) {
-  const val = de.pop();
+    const val = de.pop();
 
-  return val != 0
+    return val != 0
 }
 function deserializeU8(de) {
-  return de.pop()
+    return de.pop()
 }
 function deserializeU32(de) {
-  return de_varint(de, 32)
+    return de_varint(de, 32)
 }
 function deserializeU64(de) {
   return de_varint_big(de, 64)
 }
 function deserializeS8(de) {
-  const buf = new ArrayBuffer(1);
-  const view = new DataView(buf);
+    const buf = new ArrayBuffer(1);
+    const view = new DataView(buf);
 
-  buf[0] = view.setUint8(0, de.pop());
+    buf[0] = view.setUint8(0, de.pop());
 
-  return view.getInt8(0);
+    return view.getInt8(0);
 }
 function deserializeS32(de) {
-  const n = de_varint(de, 32)
+    const n = de_varint(de, 32)
 
-  return Number(((n >> 1) & 0xFFFFFFFF) ^ (-((n & 0b1) & 0xFFFFFFFF)))
+    return Number(((n >> 1) & 0xFFFFFFFF) ^ (-((n & 0b1) & 0xFFFFFFFF)))
 }
 function deserializeS64(de) {
   const n = de_varint_big(de, 64)
@@ -111,62 +111,62 @@ function deserializeS64(de) {
   return ((n >> 1n) & 0xFFFFFFFFFFFFFFFFn) ^ (-((n & 0b1n) & 0xFFFFFFFFFFFFFFFFn))
 }
 function deserializeF32(de) {
-  const bytes = de.try_take_n(4);
+    const bytes = de.try_take_n(4);
 
-  const buf = new ArrayBuffer(4);
-  const view = new DataView(buf);
+    const buf = new ArrayBuffer(4);
+    const view = new DataView(buf);
 
-  bytes.forEach((v, i) => view.setUint8(i, v));
+    bytes.forEach((v, i) => view.setUint8(i, v));
 
-  return view.getFloat32(0, true);
+    return view.getFloat32(0, true);
 }
 function deserializeF64(de) {
-  const bytes = de.try_take_n(8);
+    const bytes = de.try_take_n(8);
 
-  const buf = new ArrayBuffer(8);
-  const view = new DataView(buf);
+    const buf = new ArrayBuffer(8);
+    const view = new DataView(buf);
 
-  bytes.forEach((v, i) => view.setUint8(i, v));
+    bytes.forEach((v, i) => view.setUint8(i, v));
 
-  return view.getFloat64(0, true);
+    return view.getFloat64(0, true);
 }
 function deserializeString(de) {
-  const sz = deserializeU64(de);
+    const sz = deserializeU64(de);
 
-  let bytes = de.try_take_n(Number(sz));
+    let bytes = de.try_take_n(Number(sz));
 
-  return __text_decoder.decode(bytes);
+    return __text_decoder.decode(bytes);
 }
 function deserializeBytes(de) {
-  const sz = deserializeU64(de);
+    const sz = deserializeU64(de);
 
-  let bytes = de.try_take_n(Number(sz));
+    let bytes = de.try_take_n(Number(sz));
 
-  return bytes;
+    return bytes;
 }
 function deserializeOption(de, inner) {
-  const tag = de.pop()
+    const tag = de.pop()
 
-  switch (tag) {
-    case 0:
-      return null
-    case 1:
-      return inner(de)
-    default:
-      throw new Error(`Deserialize bad option ${tag}`)
-  }
+    switch (tag) {
+        case 0:
+            return null
+        case 1: 
+            return inner(de)
+        default:
+            throw new Error(`Deserialize bad option ${tag}`)
+    }
 }
 function deserializeResult(de, ok, err) {
-  const tag = de.pop()
+    const tag = de.pop()
 
-  switch (tag) {
-    case 0:
-      return { tag: 'ok', val: ok(de) }
-    case 1:
-      return { tag: 'err', val: err(de) }
-    default:
-      throw new Error(`Deserialize bad result ${tag}`)
-  }
+    switch (tag) {
+        case 0:
+            return { tag: 'ok', val: ok(de) }
+        case 1: 
+            return { tag: 'err', val: err(de) }
+        default:
+            throw new Error(`Deserialize bad result ${tag}`)
+    }
 }
 function ser_varint(out, bits, val) {
   let buf = []
@@ -204,370 +204,370 @@ function ser_varint_big(out, bits, val) {
   out.push(...buf)
 }
 function serializeBool(out, val) {
-  out.push(val === true ? 1 : 0)
+    out.push(val === true ? 1 : 0)
 }
 function serializeU8(out, val) {
-  return out.push(val)
+    return out.push(val)
 }
 function serializeU32(out, val) {
-  return ser_varint(out, 32, val)
+    return ser_varint(out, 32, val)
 }
 function serializeU64(out, val) {
   return ser_varint_big(out, 64, BigInt(val))
 }
 function serializeS8(out, val) {
-  out.push(val)
+    out.push(val)
 }
 function serializeS32(out, val) {
-  ser_varint(out, 32, (val << 1) ^ (val >> 31))
+    ser_varint(out, 32, (val << 1) ^ (val >> 31))
 }
 function serializeS64(out, val) {
   val = BigInt(val)
   ser_varint_big(out, 64, (val << 1n) ^ (val >> 63n))
 }
 function serializeF32(out, val) {
-  const buf = new ArrayBuffer(4);
-  const view = new DataView(buf);
+    const buf = new ArrayBuffer(4);
+    const view = new DataView(buf);
 
-  view.setFloat32(0, val, true);
+    view.setFloat32(0, val, true);
 
-  out.push(...new Uint8Array(buf))
+    out.push(...new Uint8Array(buf))
 }
 function serializeF64(out, val) {
-  const buf = new ArrayBuffer(8);
-  const view = new DataView(buf);
+    const buf = new ArrayBuffer(8);
+    const view = new DataView(buf);
 
-  view.setFloat64(0, val, true);
+    view.setFloat64(0, val, true);
 
-  out.push(...new Uint8Array(buf))
+    out.push(...new Uint8Array(buf))
 }
 function serializeString(out, val) {
-  serializeU64(out, val.length);
+    serializeU64(out, val.length);
 
-  out.push(...__text_encoder.encode(val))
+    out.push(...__text_encoder.encode(val))
 }
 function serializeBytes(out, val) {
-  serializeU64(out, val.length);
-  out.push(...val)
+    serializeU64(out, val.length);
+    out.push(...val)
 }
 function serializeOption(out, inner, val) {
-  serializeU8(out, !!val ? 1 : 0)
-  if (val) {
-    inner(out, val)
-  }
+    serializeU8(out, !!val ? 1 : 0)
+    if (val) {
+        inner(out, val)
+    }
 }
 function serializeResult(out, ok, err, val) {
-  if (val.Ok) {
-    serializeU8(out, 0);
-    return ok(out, val.Ok);
-  }
+    if (val.Ok) {
+        serializeU8(out, 0);
+        return ok(out, val.Ok);
+    }
 
-  if (val.Err) {
-    serializeU8(out, 1);
-    return err(out, val.Err);
-  }
+    if (val.Err) {
+        serializeU8(out, 1);
+        return err(out, val.Err);
+    }
 
-  throw new Error(`Serialize bad result ${val}`);
+    throw new Error(`Serialize bad result ${val}`);
 }
 const __text_decoder = new TextDecoder('utf-8');
 const __text_encoder = new TextEncoder();
 function deserializeE1(de) {
-  const tag = deserializeU32(de)
+    const tag = deserializeU32(de)
 
-  switch (tag) {
-    case 0:
-      return "A"
+    switch (tag) {
+        case 0:
+    return "A"
 
-    default:
-      throw new Error(`unknown enum case ${tag}`)
-  }
-} function deserializeU1(de) {
-  const tag = deserializeU32(de)
+        default:
+            throw new Error(`unknown enum case ${tag}`)
+    }
+}function deserializeU1(de) {
+    const tag = deserializeU32(de)
 
-  switch (tag) {
-    case 0:
-      return { U32: deserializeU32(de) }
-    case 1:
-      return { F32: deserializeF32(de) }
+    switch (tag) {
+        case 0:
+    return { U32: deserializeU32(de) }
+case 1:
+    return { F32: deserializeF32(de) }
 
-    default:
-      throw new Error(`unknown union case ${tag}`)
-  }
-} function deserializeEmpty(de) {
-  return {
+        default:
+            throw new Error(`unknown union case ${tag}`)
+    }
+}function deserializeEmpty(de) {
+    return {
+        
+    }
+}function deserializeV1(de) {
+    const tag = deserializeU32(de)
 
-  }
-} function deserializeV1(de) {
-  const tag = deserializeU32(de)
+    switch (tag) {
+        case 0:
+    return { A: null }
+case 1:
+    return { B: deserializeU1(de) }
+case 2:
+    return { C: deserializeE1(de) }
+case 3:
+    return { D: deserializeString(de) }
+case 4:
+    return { E: deserializeEmpty(de) }
+case 5:
+    return { F: null }
+case 6:
+    return { G: deserializeU32(de) }
 
-  switch (tag) {
-    case 0:
-      return { A: null }
-    case 1:
-      return { B: deserializeU1(de) }
-    case 2:
-      return { C: deserializeE1(de) }
-    case 3:
-      return { D: deserializeString(de) }
-    case 4:
-      return { E: deserializeEmpty(de) }
-    case 5:
-      return { F: null }
-    case 6:
-      return { G: deserializeU32(de) }
+        default:
+            throw new Error(`unknown variant case ${tag}`)
+    }
+}function deserializeCasts1(de) {
+    const tag = deserializeU32(de)
 
-    default:
-      throw new Error(`unknown variant case ${tag}`)
-  }
-} function deserializeCasts1(de) {
-  const tag = deserializeU32(de)
+    switch (tag) {
+        case 0:
+    return { A: deserializeS32(de) }
+case 1:
+    return { B: deserializeF32(de) }
 
-  switch (tag) {
-    case 0:
-      return { A: deserializeS32(de) }
-    case 1:
-      return { B: deserializeF32(de) }
+        default:
+            throw new Error(`unknown variant case ${tag}`)
+    }
+}function deserializeCasts2(de) {
+    const tag = deserializeU32(de)
 
-    default:
-      throw new Error(`unknown variant case ${tag}`)
-  }
-} function deserializeCasts2(de) {
-  const tag = deserializeU32(de)
+    switch (tag) {
+        case 0:
+    return { A: deserializeF64(de) }
+case 1:
+    return { B: deserializeF32(de) }
 
-  switch (tag) {
-    case 0:
-      return { A: deserializeF64(de) }
-    case 1:
-      return { B: deserializeF32(de) }
+        default:
+            throw new Error(`unknown variant case ${tag}`)
+    }
+}function deserializeCasts3(de) {
+    const tag = deserializeU32(de)
 
-    default:
-      throw new Error(`unknown variant case ${tag}`)
-  }
-} function deserializeCasts3(de) {
-  const tag = deserializeU32(de)
+    switch (tag) {
+        case 0:
+    return { A: deserializeF64(de) }
+case 1:
+    return { B: deserializeU64(de) }
 
-  switch (tag) {
-    case 0:
-      return { A: deserializeF64(de) }
-    case 1:
-      return { B: deserializeU64(de) }
+        default:
+            throw new Error(`unknown variant case ${tag}`)
+    }
+}function deserializeCasts4(de) {
+    const tag = deserializeU32(de)
 
-    default:
-      throw new Error(`unknown variant case ${tag}`)
-  }
-} function deserializeCasts4(de) {
-  const tag = deserializeU32(de)
+    switch (tag) {
+        case 0:
+    return { A: deserializeU32(de) }
+case 1:
+    return { B: deserializeS64(de) }
 
-  switch (tag) {
-    case 0:
-      return { A: deserializeU32(de) }
-    case 1:
-      return { B: deserializeS64(de) }
+        default:
+            throw new Error(`unknown variant case ${tag}`)
+    }
+}function deserializeCasts5(de) {
+    const tag = deserializeU32(de)
 
-    default:
-      throw new Error(`unknown variant case ${tag}`)
-  }
-} function deserializeCasts5(de) {
-  const tag = deserializeU32(de)
+    switch (tag) {
+        case 0:
+    return { A: deserializeF32(de) }
+case 1:
+    return { B: deserializeS64(de) }
 
-  switch (tag) {
-    case 0:
-      return { A: deserializeF32(de) }
-    case 1:
-      return { B: deserializeS64(de) }
+        default:
+            throw new Error(`unknown variant case ${tag}`)
+    }
+}function deserializeCasts6(de) {
+    const tag = deserializeU32(de)
 
-    default:
-      throw new Error(`unknown variant case ${tag}`)
-  }
-} function deserializeCasts6(de) {
-  const tag = deserializeU32(de)
+    switch (tag) {
+        case 0:
+    return { A: [deserializeF32(de), deserializeU32(de)] }
+case 1:
+    return { B: [deserializeU32(de), deserializeU32(de)] }
 
-  switch (tag) {
-    case 0:
-      return { A: [deserializeF32(de), deserializeU32(de)] }
-    case 1:
-      return { B: [deserializeU32(de), deserializeU32(de)] }
+        default:
+            throw new Error(`unknown variant case ${tag}`)
+    }
+}function deserializeMyErrno(de) {
+    const tag = deserializeU32(de)
 
-    default:
-      throw new Error(`unknown variant case ${tag}`)
-  }
-} function deserializeMyErrno(de) {
-  const tag = deserializeU32(de)
+    switch (tag) {
+        case 0:
+    return "Bad1"
+case 1:
+    return "Bad2"
 
-  switch (tag) {
-    case 0:
-      return "Bad1"
-    case 1:
-      return "Bad2"
+        default:
+            throw new Error(`unknown enum case ${tag}`)
+    }
+}function deserializeIsClone(de) {
+    return {
+        v1: deserializeV1(de)
+    }
+}function serializeE1(out, val) {
+    switch (val) {
+        case "A":
+    serializeU32(out, 0)
+    return
 
-    default:
-      throw new Error(`unknown enum case ${tag}`)
-  }
-} function deserializeIsClone(de) {
-  return {
-    v1: deserializeV1(de)
-  }
-} function serializeE1(out, val) {
-  switch (val) {
-    case "A":
-      serializeU32(out, 0)
-      return
-
-    default:
-      throw new Error("unknown enum case")
-  }
-} function serializeU1(out, val) {
-  if (val.U32) {
+        default:
+            throw new Error("unknown enum case")
+    }
+}function serializeU1(out, val) {
+    if (val.U32) {
     serializeU32(out, 0);
     return serializeU32(out, val.U32)
-  }
-  if (val.F32) {
+}
+                if (val.F32) {
     serializeU32(out, 1);
     return serializeF32(out, val.F32)
-  }
+}
+                
 
-
-  throw new Error("unknown union case")
-} function serializeEmpty(out, val) {
-
-} function serializeV1(out, val) {
-  if (val.A) {
+    throw new Error("unknown union case")
+}function serializeEmpty(out, val) {
+    
+}function serializeV1(out, val) {
+    if (val.A) {
     serializeU32(out, 0);
-
+    
     return
-  }
-  if (val.B) {
+}
+if (val.B) {
     serializeU32(out, 1);
     serializeU1(out, val.B)
     return
-  }
-  if (val.C) {
+}
+if (val.C) {
     serializeU32(out, 2);
     serializeE1(out, val.C)
     return
-  }
-  if (val.D) {
+}
+if (val.D) {
     serializeU32(out, 3);
     serializeString(out, val.D)
     return
-  }
-  if (val.E) {
+}
+if (val.E) {
     serializeU32(out, 4);
     serializeEmpty(out, val.E)
     return
-  }
-  if (val.F) {
+}
+if (val.F) {
     serializeU32(out, 5);
-
+    
     return
-  }
-  if (val.G) {
+}
+if (val.G) {
     serializeU32(out, 6);
     serializeU32(out, val.G)
     return
-  }
+}
 
 
-  throw new Error("unknown variant case")
-} function serializeCasts1(out, val) {
-  if (val.A) {
+    throw new Error("unknown variant case")
+}function serializeCasts1(out, val) {
+    if (val.A) {
     serializeU32(out, 0);
     serializeS32(out, val.A)
     return
-  }
-  if (val.B) {
+}
+if (val.B) {
     serializeU32(out, 1);
     serializeF32(out, val.B)
     return
-  }
+}
 
 
-  throw new Error("unknown variant case")
-} function serializeCasts2(out, val) {
-  if (val.A) {
+    throw new Error("unknown variant case")
+}function serializeCasts2(out, val) {
+    if (val.A) {
     serializeU32(out, 0);
     serializeF64(out, val.A)
     return
-  }
-  if (val.B) {
+}
+if (val.B) {
     serializeU32(out, 1);
     serializeF32(out, val.B)
     return
-  }
+}
 
 
-  throw new Error("unknown variant case")
-} function serializeCasts3(out, val) {
-  if (val.A) {
+    throw new Error("unknown variant case")
+}function serializeCasts3(out, val) {
+    if (val.A) {
     serializeU32(out, 0);
     serializeF64(out, val.A)
     return
-  }
-  if (val.B) {
+}
+if (val.B) {
     serializeU32(out, 1);
     serializeU64(out, val.B)
     return
-  }
+}
 
 
-  throw new Error("unknown variant case")
-} function serializeCasts4(out, val) {
-  if (val.A) {
+    throw new Error("unknown variant case")
+}function serializeCasts4(out, val) {
+    if (val.A) {
     serializeU32(out, 0);
     serializeU32(out, val.A)
     return
-  }
-  if (val.B) {
+}
+if (val.B) {
     serializeU32(out, 1);
     serializeS64(out, val.B)
     return
-  }
+}
 
 
-  throw new Error("unknown variant case")
-} function serializeCasts5(out, val) {
-  if (val.A) {
+    throw new Error("unknown variant case")
+}function serializeCasts5(out, val) {
+    if (val.A) {
     serializeU32(out, 0);
     serializeF32(out, val.A)
     return
-  }
-  if (val.B) {
+}
+if (val.B) {
     serializeU32(out, 1);
     serializeS64(out, val.B)
     return
-  }
+}
 
 
-  throw new Error("unknown variant case")
-} function serializeCasts6(out, val) {
-  if (val.A) {
+    throw new Error("unknown variant case")
+}function serializeCasts6(out, val) {
+    if (val.A) {
     serializeU32(out, 0);
-    { serializeF32(out, val.A[0]); serializeU32(out, val.A[1]) }
+    {serializeF32(out, val.A[0]);serializeU32(out, val.A[1])}
     return
-  }
-  if (val.B) {
+}
+if (val.B) {
     serializeU32(out, 1);
-    { serializeU32(out, val.B[0]); serializeU32(out, val.B[1]) }
+    {serializeU32(out, val.B[0]);serializeU32(out, val.B[1])}
     return
-  }
-
-
-  throw new Error("unknown variant case")
-} function serializeIsClone(out, val) {
-  serializeV1(out, val.v1)
 }
 
-export enum E1 {
-  A,
+
+    throw new Error("unknown variant case")
+}function serializeIsClone(out, val) {
+    serializeV1(out, val.v1)
 }
 
-export type U1 =
-  number
-  |
-  number
-  ;
+export enum E1 { 
+A,
+ }
 
-export interface Empty { }
+export type U1 = 
+number
+ | 
+number
+;
+
+export interface Empty {  }
 
 export interface V1A { tag: 0 }
 
@@ -584,386 +584,387 @@ export interface V1F { tag: 5 }
 export interface V1G { tag: 6, value: number }
 
 
-export type V1 =
-  V1A |
-  V1B |
-  V1C |
-  V1D |
-  V1E |
-  V1F |
-  V1G
+export type V1 = 
+V1A | 
+V1B | 
+V1C | 
+V1D | 
+V1E | 
+V1F | 
+V1G
 
 export interface Casts1A { tag: 0, value: number }
 
 export interface Casts1B { tag: 1, value: number }
 
 
-export type Casts1 =
-  Casts1A |
-  Casts1B
+export type Casts1 = 
+Casts1A | 
+Casts1B
 
 export interface Casts2A { tag: 0, value: number }
 
 export interface Casts2B { tag: 1, value: number }
 
 
-export type Casts2 =
-  Casts2A |
-  Casts2B
+export type Casts2 = 
+Casts2A | 
+Casts2B
 
 export interface Casts3A { tag: 0, value: number }
 
 export interface Casts3B { tag: 1, value: bigint }
 
 
-export type Casts3 =
-  Casts3A |
-  Casts3B
+export type Casts3 = 
+Casts3A | 
+Casts3B
 
 export interface Casts4A { tag: 0, value: number }
 
 export interface Casts4B { tag: 1, value: bigint }
 
 
-export type Casts4 =
-  Casts4A |
-  Casts4B
+export type Casts4 = 
+Casts4A | 
+Casts4B
 
 export interface Casts5A { tag: 0, value: number }
 
 export interface Casts5B { tag: 1, value: bigint }
 
 
-export type Casts5 =
-  Casts5A |
-  Casts5B
+export type Casts5 = 
+Casts5A | 
+Casts5B
 
 export interface Casts6A { tag: 0, value: [number, number] }
 
 export interface Casts6B { tag: 1, value: [number, number] }
 
 
-export type Casts6 =
-  Casts6A |
-  Casts6B
+export type Casts6 = 
+Casts6A | 
+Casts6B
 
-export enum MyErrno {
-  Bad1,
+export enum MyErrno { 
+Bad1,
 
-  Bad2,
+Bad2,
+ }
+
+export interface IsClone { 
+v1: V1,
+ }
+
+
+
+export async function e1Arg (x: E1) : Promise<void> {
+    const out = []
+    serializeE1(out, x)
+
+     fetch('ipc://localhost/variants/e1_arg', { method: "POST", body: Uint8Array.from(out) }) 
 }
+        
 
-export interface IsClone {
-  v1: V1,
+export async function e1Result () : Promise<E1> {
+    const out = []
+    
+
+    return fetch('ipc://localhost/variants/e1_result', { method: "POST", body: Uint8Array.from(out) })
+        .then(r => r.arrayBuffer())
+        .then(bytes => {
+            const de = new Deserializer(new Uint8Array(bytes))
+
+            return deserializeE1(de)
+        }) as Promise<E1>
 }
+        
 
+export async function u1Arg (x: U1) : Promise<void> {
+    const out = []
+    serializeU1(out, x)
 
-
-export async function e1Arg(x: E1): Promise<void> {
-  const out = []
-  serializeE1(out, x)
-
-  fetch('ipc://localhost/variants/e1_arg', { method: "POST", body: Uint8Array.from(out) })
+     fetch('ipc://localhost/variants/u1_arg', { method: "POST", body: Uint8Array.from(out) }) 
 }
+        
 
+export async function u1Result () : Promise<U1> {
+    const out = []
+    
 
-export async function e1Result(): Promise<E1> {
-  const out = []
+    return fetch('ipc://localhost/variants/u1_result', { method: "POST", body: Uint8Array.from(out) })
+        .then(r => r.arrayBuffer())
+        .then(bytes => {
+            const de = new Deserializer(new Uint8Array(bytes))
 
-
-  return fetch('ipc://localhost/variants/e1_result', { method: "POST", body: Uint8Array.from(out) })
-    .then(r => r.arrayBuffer())
-    .then(bytes => {
-      const de = new Deserializer(new Uint8Array(bytes))
-
-      return deserializeE1(de)
-    }) as Promise<E1>
+            return deserializeU1(de)
+        }) as Promise<U1>
 }
+        
 
+export async function v1Arg (x: V1) : Promise<void> {
+    const out = []
+    serializeV1(out, x)
 
-export async function u1Arg(x: U1): Promise<void> {
-  const out = []
-  serializeU1(out, x)
-
-  fetch('ipc://localhost/variants/u1_arg', { method: "POST", body: Uint8Array.from(out) })
+     fetch('ipc://localhost/variants/v1_arg', { method: "POST", body: Uint8Array.from(out) }) 
 }
+        
 
+export async function v1Result () : Promise<V1> {
+    const out = []
+    
 
-export async function u1Result(): Promise<U1> {
-  const out = []
+    return fetch('ipc://localhost/variants/v1_result', { method: "POST", body: Uint8Array.from(out) })
+        .then(r => r.arrayBuffer())
+        .then(bytes => {
+            const de = new Deserializer(new Uint8Array(bytes))
 
-
-  return fetch('ipc://localhost/variants/u1_result', { method: "POST", body: Uint8Array.from(out) })
-    .then(r => r.arrayBuffer())
-    .then(bytes => {
-      const de = new Deserializer(new Uint8Array(bytes))
-
-      return deserializeU1(de)
-    }) as Promise<U1>
+            return deserializeV1(de)
+        }) as Promise<V1>
 }
+        
 
+export async function boolArg (x: boolean) : Promise<void> {
+    const out = []
+    serializeBool(out, x)
 
-export async function v1Arg(x: V1): Promise<void> {
-  const out = []
-  serializeV1(out, x)
-
-  fetch('ipc://localhost/variants/v1_arg', { method: "POST", body: Uint8Array.from(out) })
+     fetch('ipc://localhost/variants/bool_arg', { method: "POST", body: Uint8Array.from(out) }) 
 }
+        
 
+export async function boolResult () : Promise<boolean> {
+    const out = []
+    
 
-export async function v1Result(): Promise<V1> {
-  const out = []
+    return fetch('ipc://localhost/variants/bool_result', { method: "POST", body: Uint8Array.from(out) })
+        .then(r => r.arrayBuffer())
+        .then(bytes => {
+            const de = new Deserializer(new Uint8Array(bytes))
 
-
-  return fetch('ipc://localhost/variants/v1_result', { method: "POST", body: Uint8Array.from(out) })
-    .then(r => r.arrayBuffer())
-    .then(bytes => {
-      const de = new Deserializer(new Uint8Array(bytes))
-
-      return deserializeV1(de)
-    }) as Promise<V1>
+            return deserializeBool(de)
+        }) as Promise<boolean>
 }
+        
 
+export async function optionArg (a: boolean | null, b: [] | null, c: number | null, d: E1 | null, e: number | null, f: U1 | null, g: boolean | null | null) : Promise<void> {
+    const out = []
+    serializeOption(out, (out, v) => serializeBool(out, v), a);
+serializeOption(out, (out, v) => {}, b);
+serializeOption(out, (out, v) => serializeU32(out, v), c);
+serializeOption(out, (out, v) => serializeE1(out, v), d);
+serializeOption(out, (out, v) => serializeF32(out, v), e);
+serializeOption(out, (out, v) => serializeU1(out, v), f);
+serializeOption(out, (out, v) => serializeOption(out, (out, v) => serializeBool(out, v), v), g)
 
-export async function boolArg(x: boolean): Promise<void> {
-  const out = []
-  serializeBool(out, x)
-
-  fetch('ipc://localhost/variants/bool_arg', { method: "POST", body: Uint8Array.from(out) })
+     fetch('ipc://localhost/variants/option_arg', { method: "POST", body: Uint8Array.from(out) }) 
 }
+        
 
+export async function optionResult () : Promise<[boolean | null, [] | null, number | null, E1 | null, number | null, U1 | null, boolean | null | null]> {
+    const out = []
+    
 
-export async function boolResult(): Promise<boolean> {
-  const out = []
+    return fetch('ipc://localhost/variants/option_result', { method: "POST", body: Uint8Array.from(out) })
+        .then(r => r.arrayBuffer())
+        .then(bytes => {
+            const de = new Deserializer(new Uint8Array(bytes))
 
-
-  return fetch('ipc://localhost/variants/bool_result', { method: "POST", body: Uint8Array.from(out) })
-    .then(r => r.arrayBuffer())
-    .then(bytes => {
-      const de = new Deserializer(new Uint8Array(bytes))
-
-      return deserializeBool(de)
-    }) as Promise<boolean>
+            return [deserializeOption(de, (de) => deserializeBool(de)), deserializeOption(de, (de) => []), deserializeOption(de, (de) => deserializeU32(de)), deserializeOption(de, (de) => deserializeE1(de)), deserializeOption(de, (de) => deserializeF32(de)), deserializeOption(de, (de) => deserializeU1(de)), deserializeOption(de, (de) => deserializeOption(de, (de) => deserializeBool(de)))]
+        }) as Promise<[boolean | null, [] | null, number | null, E1 | null, number | null, U1 | null, boolean | null | null]>
 }
+        
 
+export async function casts (a: Casts1, b: Casts2, c: Casts3, d: Casts4, e: Casts5, f: Casts6) : Promise<[Casts1, Casts2, Casts3, Casts4, Casts5, Casts6]> {
+    const out = []
+    serializeCasts1(out, a);
+serializeCasts2(out, b);
+serializeCasts3(out, c);
+serializeCasts4(out, d);
+serializeCasts5(out, e);
+serializeCasts6(out, f)
 
-export async function optionArg(a: boolean | null, b: [] | null, c: number | null, d: E1 | null, e: number | null, f: U1 | null, g: boolean | null | null): Promise<void> {
-  const out = []
-  serializeOption(out, (out, v) => serializeBool(out, v), a);
-  serializeOption(out, (out, v) => { }, b);
-  serializeOption(out, (out, v) => serializeU32(out, v), c);
-  serializeOption(out, (out, v) => serializeE1(out, v), d);
-  serializeOption(out, (out, v) => serializeF32(out, v), e);
-  serializeOption(out, (out, v) => serializeU1(out, v), f);
-  serializeOption(out, (out, v) => serializeOption(out, (out, v) => serializeBool(out, v), v), g)
+    return fetch('ipc://localhost/variants/casts', { method: "POST", body: Uint8Array.from(out) })
+        .then(r => r.arrayBuffer())
+        .then(bytes => {
+            const de = new Deserializer(new Uint8Array(bytes))
 
-  fetch('ipc://localhost/variants/option_arg', { method: "POST", body: Uint8Array.from(out) })
+            return [deserializeCasts1(de), deserializeCasts2(de), deserializeCasts3(de), deserializeCasts4(de), deserializeCasts5(de), deserializeCasts6(de)]
+        }) as Promise<[Casts1, Casts2, Casts3, Casts4, Casts5, Casts6]>
 }
+        
 
+export async function resultArg (a: Result<null, null>, b: Result<null, E1>, c: Result<E1, null>, d: Result<[], []>, e: Result<number, V1>, f: Result<string, Uint8Array[]>) : Promise<void> {
+    const out = []
+    serializeResult(out, (out, v) => {}, (out, v) => {}, a);
+serializeResult(out, (out, v) => {}, (out, v) => serializeE1(out, v), b);
+serializeResult(out, (out, v) => serializeE1(out, v), (out, v) => {}, c);
+serializeResult(out, (out, v) => {}, (out, v) => {}, d);
+serializeResult(out, (out, v) => serializeU32(out, v), (out, v) => serializeV1(out, v), e);
+serializeResult(out, (out, v) => serializeString(out, v), (out, v) => serializeBytes(out, v), f)
 
-export async function optionResult(): Promise<[boolean | null, [] | null, number | null, E1 | null, number | null, U1 | null, boolean | null | null]> {
-  const out = []
-
-
-  return fetch('ipc://localhost/variants/option_result', { method: "POST", body: Uint8Array.from(out) })
-    .then(r => r.arrayBuffer())
-    .then(bytes => {
-      const de = new Deserializer(new Uint8Array(bytes))
-
-      return [deserializeOption(de, (de) => deserializeBool(de)), deserializeOption(de, (de) => []), deserializeOption(de, (de) => deserializeU32(de)), deserializeOption(de, (de) => deserializeE1(de)), deserializeOption(de, (de) => deserializeF32(de)), deserializeOption(de, (de) => deserializeU1(de)), deserializeOption(de, (de) => deserializeOption(de, (de) => deserializeBool(de)))]
-    }) as Promise<[boolean | null, [] | null, number | null, E1 | null, number | null, U1 | null, boolean | null | null]>
+     fetch('ipc://localhost/variants/result_arg', { method: "POST", body: Uint8Array.from(out) }) 
 }
+        
 
+export async function resultResult () : Promise<[Result<null, null>, Result<null, E1>, Result<E1, null>, Result<[], []>, Result<number, V1>, Result<string, Uint8Array[]>]> {
+    const out = []
+    
 
-export async function casts(a: Casts1, b: Casts2, c: Casts3, d: Casts4, e: Casts5, f: Casts6): Promise<[Casts1, Casts2, Casts3, Casts4, Casts5, Casts6]> {
-  const out = []
-  serializeCasts1(out, a);
-  serializeCasts2(out, b);
-  serializeCasts3(out, c);
-  serializeCasts4(out, d);
-  serializeCasts5(out, e);
-  serializeCasts6(out, f)
+    return fetch('ipc://localhost/variants/result_result', { method: "POST", body: Uint8Array.from(out) })
+        .then(r => r.arrayBuffer())
+        .then(bytes => {
+            const de = new Deserializer(new Uint8Array(bytes))
 
-  return fetch('ipc://localhost/variants/casts', { method: "POST", body: Uint8Array.from(out) })
-    .then(r => r.arrayBuffer())
-    .then(bytes => {
-      const de = new Deserializer(new Uint8Array(bytes))
-
-      return [deserializeCasts1(de), deserializeCasts2(de), deserializeCasts3(de), deserializeCasts4(de), deserializeCasts5(de), deserializeCasts6(de)]
-    }) as Promise<[Casts1, Casts2, Casts3, Casts4, Casts5, Casts6]>
+            return [deserializeResult(de, () => {}, () => {}), deserializeResult(de, () => {}, (de) => deserializeE1(de)), deserializeResult(de, (de) => deserializeE1(de), () => {}), deserializeResult(de, (de) => [], (de) => []), deserializeResult(de, (de) => deserializeU32(de), (de) => deserializeV1(de)), deserializeResult(de, (de) => deserializeString(de), (de) => deserializeBytes(de))]
+        }) as Promise<[Result<null, null>, Result<null, E1>, Result<E1, null>, Result<[], []>, Result<number, V1>, Result<string, Uint8Array[]>]>
 }
+        
 
+export async function returnResultSugar () : Promise<Result<number, MyErrno>> {
+    const out = []
+    
 
-export async function resultArg(a: Result<null, null>, b: Result<null, E1>, c: Result<E1, null>, d: Result<[], []>, e: Result<number, V1>, f: Result<string, Uint8Array[]>): Promise<void> {
-  const out = []
-  serializeResult(out, (out, v) => { }, (out, v) => { }, a);
-  serializeResult(out, (out, v) => { }, (out, v) => serializeE1(out, v), b);
-  serializeResult(out, (out, v) => serializeE1(out, v), (out, v) => { }, c);
-  serializeResult(out, (out, v) => { }, (out, v) => { }, d);
-  serializeResult(out, (out, v) => serializeU32(out, v), (out, v) => serializeV1(out, v), e);
-  serializeResult(out, (out, v) => serializeString(out, v), (out, v) => serializeBytes(out, v), f)
+    return fetch('ipc://localhost/variants/return_result_sugar', { method: "POST", body: Uint8Array.from(out) })
+        .then(r => r.arrayBuffer())
+        .then(bytes => {
+            const de = new Deserializer(new Uint8Array(bytes))
 
-  fetch('ipc://localhost/variants/result_arg', { method: "POST", body: Uint8Array.from(out) })
+            return deserializeResult(de, (de) => deserializeS32(de), (de) => deserializeMyErrno(de))
+        }) as Promise<Result<number, MyErrno>>
 }
+        
 
+export async function returnResultSugar2 () : Promise<Result<null, MyErrno>> {
+    const out = []
+    
 
-export async function resultResult(): Promise<[Result<null, null>, Result<null, E1>, Result<E1, null>, Result<[], []>, Result<number, V1>, Result<string, Uint8Array[]>]> {
-  const out = []
+    return fetch('ipc://localhost/variants/return_result_sugar2', { method: "POST", body: Uint8Array.from(out) })
+        .then(r => r.arrayBuffer())
+        .then(bytes => {
+            const de = new Deserializer(new Uint8Array(bytes))
 
-
-  return fetch('ipc://localhost/variants/result_result', { method: "POST", body: Uint8Array.from(out) })
-    .then(r => r.arrayBuffer())
-    .then(bytes => {
-      const de = new Deserializer(new Uint8Array(bytes))
-
-      return [deserializeResult(de, () => { }, () => { }), deserializeResult(de, () => { }, (de) => deserializeE1(de)), deserializeResult(de, (de) => deserializeE1(de), () => { }), deserializeResult(de, (de) => [], (de) => []), deserializeResult(de, (de) => deserializeU32(de), (de) => deserializeV1(de)), deserializeResult(de, (de) => deserializeString(de), (de) => deserializeBytes(de))]
-    }) as Promise<[Result<null, null>, Result<null, E1>, Result<E1, null>, Result<[], []>, Result<number, V1>, Result<string, Uint8Array[]>]>
+            return deserializeResult(de, () => {}, (de) => deserializeMyErrno(de))
+        }) as Promise<Result<null, MyErrno>>
 }
+        
 
+export async function returnResultSugar3 () : Promise<Result<MyErrno, MyErrno>> {
+    const out = []
+    
 
-export async function returnResultSugar(): Promise<Result<number, MyErrno>> {
-  const out = []
+    return fetch('ipc://localhost/variants/return_result_sugar3', { method: "POST", body: Uint8Array.from(out) })
+        .then(r => r.arrayBuffer())
+        .then(bytes => {
+            const de = new Deserializer(new Uint8Array(bytes))
 
-
-  return fetch('ipc://localhost/variants/return_result_sugar', { method: "POST", body: Uint8Array.from(out) })
-    .then(r => r.arrayBuffer())
-    .then(bytes => {
-      const de = new Deserializer(new Uint8Array(bytes))
-
-      return deserializeResult(de, (de) => deserializeS32(de), (de) => deserializeMyErrno(de))
-    }) as Promise<Result<number, MyErrno>>
+            return deserializeResult(de, (de) => deserializeMyErrno(de), (de) => deserializeMyErrno(de))
+        }) as Promise<Result<MyErrno, MyErrno>>
 }
+        
 
+export async function returnResultSugar4 () : Promise<Result<[number, number], MyErrno>> {
+    const out = []
+    
 
-export async function returnResultSugar2(): Promise<Result<null, MyErrno>> {
-  const out = []
+    return fetch('ipc://localhost/variants/return_result_sugar4', { method: "POST", body: Uint8Array.from(out) })
+        .then(r => r.arrayBuffer())
+        .then(bytes => {
+            const de = new Deserializer(new Uint8Array(bytes))
 
-
-  return fetch('ipc://localhost/variants/return_result_sugar2', { method: "POST", body: Uint8Array.from(out) })
-    .then(r => r.arrayBuffer())
-    .then(bytes => {
-      const de = new Deserializer(new Uint8Array(bytes))
-
-      return deserializeResult(de, () => { }, (de) => deserializeMyErrno(de))
-    }) as Promise<Result<null, MyErrno>>
+            return deserializeResult(de, (de) => [deserializeS32(de), deserializeU32(de)], (de) => deserializeMyErrno(de))
+        }) as Promise<Result<[number, number], MyErrno>>
 }
+        
 
+export async function returnOptionSugar () : Promise<number | null> {
+    const out = []
+    
 
-export async function returnResultSugar3(): Promise<Result<MyErrno, MyErrno>> {
-  const out = []
+    return fetch('ipc://localhost/variants/return_option_sugar', { method: "POST", body: Uint8Array.from(out) })
+        .then(r => r.arrayBuffer())
+        .then(bytes => {
+            const de = new Deserializer(new Uint8Array(bytes))
 
-
-  return fetch('ipc://localhost/variants/return_result_sugar3', { method: "POST", body: Uint8Array.from(out) })
-    .then(r => r.arrayBuffer())
-    .then(bytes => {
-      const de = new Deserializer(new Uint8Array(bytes))
-
-      return deserializeResult(de, (de) => deserializeMyErrno(de), (de) => deserializeMyErrno(de))
-    }) as Promise<Result<MyErrno, MyErrno>>
+            return deserializeOption(de, (de) => deserializeS32(de))
+        }) as Promise<number | null>
 }
+        
 
+export async function returnOptionSugar2 () : Promise<MyErrno | null> {
+    const out = []
+    
 
-export async function returnResultSugar4(): Promise<Result<[number, number], MyErrno>> {
-  const out = []
+    return fetch('ipc://localhost/variants/return_option_sugar2', { method: "POST", body: Uint8Array.from(out) })
+        .then(r => r.arrayBuffer())
+        .then(bytes => {
+            const de = new Deserializer(new Uint8Array(bytes))
 
-
-  return fetch('ipc://localhost/variants/return_result_sugar4', { method: "POST", body: Uint8Array.from(out) })
-    .then(r => r.arrayBuffer())
-    .then(bytes => {
-      const de = new Deserializer(new Uint8Array(bytes))
-
-      return deserializeResult(de, (de) => [deserializeS32(de), deserializeU32(de)], (de) => deserializeMyErrno(de))
-    }) as Promise<Result<[number, number], MyErrno>>
+            return deserializeOption(de, (de) => deserializeMyErrno(de))
+        }) as Promise<MyErrno | null>
 }
+        
 
+export async function resultSimple () : Promise<Result<number, number>> {
+    const out = []
+    
 
-export async function returnOptionSugar(): Promise<number | null> {
-  const out = []
+    return fetch('ipc://localhost/variants/result_simple', { method: "POST", body: Uint8Array.from(out) })
+        .then(r => r.arrayBuffer())
+        .then(bytes => {
+            const de = new Deserializer(new Uint8Array(bytes))
 
-
-  return fetch('ipc://localhost/variants/return_option_sugar', { method: "POST", body: Uint8Array.from(out) })
-    .then(r => r.arrayBuffer())
-    .then(bytes => {
-      const de = new Deserializer(new Uint8Array(bytes))
-
-      return deserializeOption(de, (de) => deserializeS32(de))
-    }) as Promise<number | null>
+            return deserializeResult(de, (de) => deserializeU32(de), (de) => deserializeS32(de))
+        }) as Promise<Result<number, number>>
 }
+        
 
+export async function isCloneArg (a: IsClone) : Promise<void> {
+    const out = []
+    serializeIsClone(out, a)
 
-export async function returnOptionSugar2(): Promise<MyErrno | null> {
-  const out = []
-
-
-  return fetch('ipc://localhost/variants/return_option_sugar2', { method: "POST", body: Uint8Array.from(out) })
-    .then(r => r.arrayBuffer())
-    .then(bytes => {
-      const de = new Deserializer(new Uint8Array(bytes))
-
-      return deserializeOption(de, (de) => deserializeMyErrno(de))
-    }) as Promise<MyErrno | null>
+     fetch('ipc://localhost/variants/is_clone_arg', { method: "POST", body: Uint8Array.from(out) }) 
 }
+        
 
+export async function isCloneReturn () : Promise<IsClone> {
+    const out = []
+    
 
-export async function resultSimple(): Promise<Result<number, number>> {
-  const out = []
+    return fetch('ipc://localhost/variants/is_clone_return', { method: "POST", body: Uint8Array.from(out) })
+        .then(r => r.arrayBuffer())
+        .then(bytes => {
+            const de = new Deserializer(new Uint8Array(bytes))
 
-
-  return fetch('ipc://localhost/variants/result_simple', { method: "POST", body: Uint8Array.from(out) })
-    .then(r => r.arrayBuffer())
-    .then(bytes => {
-      const de = new Deserializer(new Uint8Array(bytes))
-
-      return deserializeResult(de, (de) => deserializeU32(de), (de) => deserializeS32(de))
-    }) as Promise<Result<number, number>>
+            return deserializeIsClone(de)
+        }) as Promise<IsClone>
 }
+        
 
+export async function returnNamedOption () : Promise<number | null> {
+    const out = []
+    
 
-export async function isCloneArg(a: IsClone): Promise<void> {
-  const out = []
-  serializeIsClone(out, a)
+    return fetch('ipc://localhost/variants/return_named_option', { method: "POST", body: Uint8Array.from(out) })
+        .then(r => r.arrayBuffer())
+        .then(bytes => {
+            const de = new Deserializer(new Uint8Array(bytes))
 
-  fetch('ipc://localhost/variants/is_clone_arg', { method: "POST", body: Uint8Array.from(out) })
+            return deserializeOption(de, (de) => deserializeU8(de))
+        }) as Promise<number | null>
 }
+        
 
+export async function returnNamedResult () : Promise<Result<number, MyErrno>> {
+    const out = []
+    
 
-export async function isCloneReturn(): Promise<IsClone> {
-  const out = []
+    return fetch('ipc://localhost/variants/return_named_result', { method: "POST", body: Uint8Array.from(out) })
+        .then(r => r.arrayBuffer())
+        .then(bytes => {
+            const de = new Deserializer(new Uint8Array(bytes))
 
-
-  return fetch('ipc://localhost/variants/is_clone_return', { method: "POST", body: Uint8Array.from(out) })
-    .then(r => r.arrayBuffer())
-    .then(bytes => {
-      const de = new Deserializer(new Uint8Array(bytes))
-
-      return deserializeIsClone(de)
-    }) as Promise<IsClone>
+            return deserializeResult(de, (de) => deserializeU8(de), (de) => deserializeMyErrno(de))
+        }) as Promise<Result<number, MyErrno>>
 }
-
-
-export async function returnNamedOption(): Promise<number | null> {
-  const out = []
-
-
-  return fetch('ipc://localhost/variants/return_named_option', { method: "POST", body: Uint8Array.from(out) })
-    .then(r => r.arrayBuffer())
-    .then(bytes => {
-      const de = new Deserializer(new Uint8Array(bytes))
-
-      return deserializeOption(de, (de) => deserializeU8(de))
-    }) as Promise<number | null>
-}
-
-
-export async function returnNamedResult(): Promise<Result<number, MyErrno>> {
-  const out = []
-
-
-  return fetch('ipc://localhost/variants/return_named_result', { method: "POST", body: Uint8Array.from(out) })
-    .then(r => r.arrayBuffer())
-    .then(bytes => {
-      const de = new Deserializer(new Uint8Array(bytes))
-
-      return deserializeResult(de, (de) => deserializeU8(de), (de) => deserializeMyErrno(de))
-    }) as Promise<Result<number, MyErrno>>
-}
+        

--- a/crates/gen-host/src/lib.rs
+++ b/crates/gen-host/src/lib.rs
@@ -5,15 +5,13 @@
     clippy::unused_self
 )]
 
-use std::borrow::Cow;
-use std::collections::HashSet;
-use std::path::PathBuf;
-
 use heck::ToKebabCase;
 use heck::{ToSnakeCase, ToUpperCamelCase};
 use proc_macro2::TokenStream;
 use quote::format_ident;
 use quote::quote;
+use std::collections::HashSet;
+use std::path::PathBuf;
 use tauri_bindgen_core::{Generate, GeneratorBuilder, TypeInfo, TypeInfos};
 use tauri_bindgen_gen_rust::{print_generics, BorrowMode, FnSig, RustGenerator};
 use wit_parser::{Function, FunctionResult, Interface, Type, TypeDefKind};
@@ -378,7 +376,7 @@ impl Host {
                 _ => quote! { () },
             };
 
-            let mod_name = format!("{}::resource::{}", mod_name, resource_name);
+            let mod_name = format!("{mod_name}::resource::{resource_name}");
             let get_r_ident = format_ident!("get_{}", resource_name.to_snake_case());
 
             quote! {

--- a/crates/gen-host/tests/resources.rs
+++ b/crates/gen-host/tests/resources.rs
@@ -18,10 +18,16 @@ pub mod resources {
         ) -> Result<::tauri_bindgen_host::ResourceId, ()>;
     }
     pub trait Resources: Sized {
-        type A: A;
-        fn get_a_mut(&mut self, id: ::tauri_bindgen_host::ResourceId) -> &mut Self::A;
-        type B: B;
-        fn get_b_mut(&mut self, id: ::tauri_bindgen_host::ResourceId) -> &mut Self::B;
+        type A: A + Send + Sync;
+        fn get_a(
+            &self,
+            id: ::tauri_bindgen_host::ResourceId,
+        ) -> ::tauri_bindgen_host::Result<::std::sync::Arc<Self::A>>;
+        type B: B + Send + Sync;
+        fn get_b(
+            &self,
+            id: ::tauri_bindgen_host::ResourceId,
+        ) -> ::tauri_bindgen_host::Result<::std::sync::Arc<Self::B>>;
         fn constructor_a(&self) -> ::tauri_bindgen_host::ResourceId;
         fn constructor_b(&self) -> ::tauri_bindgen_host::ResourceId;
     }
@@ -59,6 +65,99 @@ pub mod resources {
                 > {
                     let ctx = get_cx(ctx.data());
                     Ok(ctx.constructor_b())
+                },
+            )?;
+        let get_cx = ::std::sync::Arc::clone(&wrapped_get_cx);
+        router
+            .func_wrap(
+                "resources::resource::a",
+                "f1",
+                move |
+                    ctx: ::tauri_bindgen_host::ipc_router_wip::Caller<T>,
+                    this_rid: ::tauri_bindgen_host::ResourceId,
+                | -> ::tauri_bindgen_host::anyhow::Result<()> {
+                    let ctx = get_cx(ctx.data());
+                    let r = ctx.get_a(this_rid)?;
+                    Ok(r.f1())
+                },
+            )?;
+        let get_cx = ::std::sync::Arc::clone(&wrapped_get_cx);
+        router
+            .func_wrap(
+                "resources::resource::a",
+                "f2",
+                move |
+                    ctx: ::tauri_bindgen_host::ipc_router_wip::Caller<T>,
+                    this_rid: ::tauri_bindgen_host::ResourceId,
+                    a: u32,
+                | -> ::tauri_bindgen_host::anyhow::Result<()> {
+                    let ctx = get_cx(ctx.data());
+                    let r = ctx.get_a(this_rid)?;
+                    Ok(r.f2(a))
+                },
+            )?;
+        let get_cx = ::std::sync::Arc::clone(&wrapped_get_cx);
+        router
+            .func_wrap(
+                "resources::resource::a",
+                "f3",
+                move |
+                    ctx: ::tauri_bindgen_host::ipc_router_wip::Caller<T>,
+                    this_rid: ::tauri_bindgen_host::ResourceId,
+                    a: u32,
+                    b: u32,
+                | -> ::tauri_bindgen_host::anyhow::Result<()> {
+                    let ctx = get_cx(ctx.data());
+                    let r = ctx.get_a(this_rid)?;
+                    Ok(r.f3(a, b))
+                },
+            )?;
+        let get_cx = ::std::sync::Arc::clone(&wrapped_get_cx);
+        router
+            .func_wrap(
+                "resources::resource::b",
+                "f1",
+                move |
+                    ctx: ::tauri_bindgen_host::ipc_router_wip::Caller<T>,
+                    this_rid: ::tauri_bindgen_host::ResourceId,
+                | -> ::tauri_bindgen_host::anyhow::Result<
+                    ::tauri_bindgen_host::ResourceId,
+                > {
+                    let ctx = get_cx(ctx.data());
+                    let r = ctx.get_b(this_rid)?;
+                    Ok(r.f1())
+                },
+            )?;
+        let get_cx = ::std::sync::Arc::clone(&wrapped_get_cx);
+        router
+            .func_wrap(
+                "resources::resource::b",
+                "f2",
+                move |
+                    ctx: ::tauri_bindgen_host::ipc_router_wip::Caller<T>,
+                    this_rid: ::tauri_bindgen_host::ResourceId,
+                    x: ::tauri_bindgen_host::ResourceId,
+                | -> ::tauri_bindgen_host::anyhow::Result<Result<u32, ()>> {
+                    let ctx = get_cx(ctx.data());
+                    let r = ctx.get_b(this_rid)?;
+                    Ok(r.f2(x))
+                },
+            )?;
+        let get_cx = ::std::sync::Arc::clone(&wrapped_get_cx);
+        router
+            .func_wrap(
+                "resources::resource::b",
+                "f3",
+                move |
+                    ctx: ::tauri_bindgen_host::ipc_router_wip::Caller<T>,
+                    this_rid: ::tauri_bindgen_host::ResourceId,
+                    x: Option<Vec<::tauri_bindgen_host::ResourceId>>,
+                | -> ::tauri_bindgen_host::anyhow::Result<
+                    Result<::tauri_bindgen_host::ResourceId, ()>,
+                > {
+                    let ctx = get_cx(ctx.data());
+                    let r = ctx.get_b(this_rid)?;
+                    Ok(r.f3(x))
                 },
             )?;
         Ok(())

--- a/crates/gen-js/src/lib.rs
+++ b/crates/gen-js/src/lib.rs
@@ -741,7 +741,7 @@ impl SerdeUtils {
                     info |= Self::collect_type_info(typedefs, &case.ty);
                 }
             }
-            TypeDefKind::Enum(_) => {
+            TypeDefKind::Enum(_) | TypeDefKind::Resource(_) => {
                 info |= SerdeUtils::U32;
             }
             TypeDefKind::Flags(fields) => {
@@ -752,9 +752,6 @@ impl SerdeUtils {
                     wit_parser::Int::U64 => SerdeUtils::U64,
                     wit_parser::Int::U128 => SerdeUtils::U128,
                 };
-            }
-            TypeDefKind::Resource(_) => {
-                info |= SerdeUtils::U32;
             }
         }
 

--- a/crates/gen-js/src/lib.rs
+++ b/crates/gen-js/src/lib.rs
@@ -752,7 +752,9 @@ impl SerdeUtils {
                     wit_parser::Int::U128 => SerdeUtils::U128,
                 };
             }
-            TypeDefKind::Resource(_) => {}
+            TypeDefKind::Resource(_) => {
+                info |= SerdeUtils::U32;
+            }
         }
 
         log::debug!("collected info for {:?}: {:?}", typedefs[id].ident, info,);

--- a/crates/gen-js/src/lib.rs
+++ b/crates/gen-js/src/lib.rs
@@ -387,7 +387,8 @@ pub trait JavaScriptGenerator {
                 format!(
                     "if ({prop_access}) {{
     serializeU32(out, {tag});
-    return {inner}
+    {inner}
+    return
 }}
 "
                 )

--- a/crates/gen-rust/src/lib.rs
+++ b/crates/gen-rust/src/lib.rs
@@ -19,6 +19,7 @@ pub trait RustGenerator {
     fn default_param_mode(&self) -> BorrowMode;
     fn print_resource(
         &self,
+        print_resource: &str,
         docs: &str,
         ident: &Ident,
         functions: &[Function],
@@ -63,7 +64,7 @@ pub trait RustGenerator {
                         self.print_union(docs, &ident, cases, info, &borrow_mode)
                     }
                     TypeDefKind::Resource(functions) => {
-                        self.print_resource(docs, &ident, functions, info)
+                        self.print_resource(&self.interface().ident, docs, &ident, functions, info)
                     }
                 };
 

--- a/crates/host/src/lib.rs
+++ b/crates/host/src/lib.rs
@@ -1,34 +1,101 @@
-pub use tauri_bindgen_host_macro::*;
+use std::marker::PhantomData;
+use std::sync::Arc;
+use std::sync::RwLock;
+use std::{any::Any, collections::HashMap};
 
-pub use generational_arena::Arena as ResourceTable;
+pub use tauri_bindgen_host_macro::*;
 #[doc(hidden)]
 pub use {anyhow, async_trait::async_trait, bitflags, ipc_router_wip, serde, tauri, tracing};
-
-pub type ResourceId = u64;
-
 pub type Result<T> = anyhow::Result<T>;
 
-// #[derive(Debug)]
-// pub struct ResourceId<T> {
-//     id: generational_arena::Index,
-//     _m: PhantomData<T>,
-// }
+pub type ResourceId = u32;
 
-// impl<T> Clone for ResourceId<T> {
-//     fn clone(&self) -> Self {
-//         Self {
-//             id: self.id.clone(),
-//             _m: PhantomData,
-//         }
-//     }
-// }
+#[derive(Default)]
+pub struct ResourceTable(RwLock<ResourceTableInner>);
 
-// impl<T> Copy for ResourceId<T> {}
+#[derive(Default)]
+pub struct ResourceTableInner {
+    map: HashMap<ResourceId, Arc<dyn Any + Send + Sync>>,
+    next_rid: ResourceId,
+}
 
-// impl<T> PartialEq for ResourceId<T> {
-//     fn eq(&self, other: &Self) -> bool {
-//         self.id == other.id
-//     }
-// }
+impl ResourceTable {
+    /// Create an empty table. New insertions will begin at 3, above stdio.
+    pub fn new() -> Self {
+        Self(RwLock::new(ResourceTableInner {
+            map: HashMap::new(),
+            next_rid: 0,
+        }))
+    }
 
-// impl<T> Eq for ResourceId<T> {}
+    /// Insert a resource at the next available index.
+    pub fn push<T: Any + Send + Sync>(&self, a: Arc<T>) -> Result<ResourceId> {
+        let mut inner = self.0.write().unwrap();
+        // NOTE: The performance of this new key calculation could be very bad once keys wrap
+        // around.
+        if inner.map.len() == u32::MAX as usize {
+            return Err(anyhow::anyhow!("table has no free keys"));
+        }
+        loop {
+            let key = inner.next_rid;
+            inner.next_rid += 1;
+            if inner.map.contains_key(&key) {
+                continue;
+            }
+            inner.map.insert(key, a);
+            return Ok(key);
+        }
+    }
+
+    /// Check if the table has a resource at the given index.
+    pub fn contains_key(&self, key: ResourceId) -> bool {
+        self.0.read().unwrap().map.contains_key(&key)
+    }
+
+    /// Check if the resource at a given index can be downcast to a given type.
+    /// Note: this will always fail if the resource is already borrowed.
+    pub fn is<T: Any + Sized>(&self, key: ResourceId) -> bool {
+        if let Some(r) = self.0.read().unwrap().map.get(&key) {
+            r.is::<T>()
+        } else {
+            false
+        }
+    }
+
+    /// Get an Arc reference to a resource of a given type at a given index. Multiple
+    /// immutable references can be borrowed at any given time.
+    pub fn get<T: Any + Send + Sync + Sized>(&self, key: ResourceId) -> Result<Arc<T>> {
+        if let Some(r) = self.0.read().unwrap().map.get(&key).cloned() {
+            r.downcast::<T>()
+                .map_err(|_| anyhow::anyhow!("element is a different type"))
+        } else {
+            Err(anyhow::anyhow!("key not in table"))
+        }
+    }
+
+    /// Get a mutable reference to a resource of a given type at a given index.
+    /// Only one such reference can be borrowed at any given time.
+    pub fn get_mut<T: Any>(&mut self, key: ResourceId) -> Result<&mut T> {
+        let entry = match self.0.get_mut().unwrap().map.get_mut(&key) {
+            Some(entry) => entry,
+            None => return Err(anyhow::anyhow!("key not in table")),
+        };
+        let entry = match Arc::get_mut(entry) {
+            Some(entry) => entry,
+            None => return Err(anyhow::anyhow!("cannot mutably borrow shared file")),
+        };
+        entry
+            .downcast_mut::<T>()
+            .ok_or_else(|| anyhow::anyhow!("element is a different type"))
+    }
+
+    /// Remove a resource at a given index from the table and returns it.
+    pub fn take<T: Any + Send + Sync>(&self, key: ResourceId) -> Option<Arc<T>> {
+        self.0
+            .write()
+            .unwrap()
+            .map
+            .remove(&key)
+            .map(|r| r.downcast::<T>().unwrap())
+    }
+}

--- a/playground/netlify.toml
+++ b/playground/netlify.toml
@@ -2,7 +2,7 @@
   NPM_FLAGS = "--version" # prevent Netlify npm install
 [build]
   publish = 'dist'
-  command = """    
+  command = """
     cd editor
     npx pnpm install --store=node_modules/.pnpm-store
     cd ..


### PR DESCRIPTION
This finally fixes the implementation of the resource type. 

## Details

Take the following wit file:

```wit
interface has_resource {
   func constructor_a () -> a

   resource a {
      func f1()
   }
}
```

It translates into this host code:

```rust
use tauri_bindgen_host::{ResourceTable, ResourceId};

// resources are represented by their own structs, allowing them to keep their own state.
struct ResourceA;

impl has_resource::A for ResourceA {
    fn f1(&self) {
        println!("called resource method!!")
    }
}

struct Ctx {
    // there is no centrally managed resource table as with wasmtime or deno
    // instead callers manage their own resource tables.
    // While this is more verbose it's both much simpler and reduces lock contention (by splitting one big lock into multiple small ones)
    a: ResourceTable,
}

impl has_resource::HasResource for Ctx {
    type A = ResourceA;

    // this is required under the hood so the dispatcher can get the resource
    fn get_a(&self, id: ResourceId) -> ::tauri_bindgen_host::Result<Arc<Self::A>> {
        self.a.get::<Self::A>(id)
    }

    // this is the regular interface function
    fn construct_a(&self) -> ResourceId {
        self.a.push(Arc::new(ResourceA)).unwrap()
    }
}
```

## TODO list 

- [x] Host implementation
- [x] Guest JS implementation
- [x] Guest TS implementation
- [x] Guest Rust implementation
- [x] Markdown implementation