### PR TITLE
Feat: streaming functions

### DIFF
--- a/Cargo.toml
+++ b/Cargo.toml
@@ -33,6 +33,7 @@ serde = "1.0.188"
 quote = "1.0.33"
 proc-macro2 = "1.0.66"
 syn = "2.0.31"
+tauri = { git = "https://github.com/tauri-apps/tauri" }
 
 [dependencies]
 clap.workspace = true

--- a/crates/gen-guest-js/tests/streams.js
+++ b/crates/gen-guest-js/tests/streams.js
@@ -1,0 +1,108 @@
+class Deserializer {
+    source
+    offset
+    
+    constructor(bytes) {
+        this.source = bytes
+        this.offset = 0
+    }
+
+    pop() {
+        return this.source[this.offset++]
+    }
+
+    try_take_n(len) {
+        const out = this.source.slice(this.offset, this.offset + len)
+        this.offset += len
+        return out
+    }
+}
+// function varint_max(bits) {
+//   const BITS_PER_BYTE = 8;
+//   const BITS_PER_VARINT_BYTE = 7;
+
+//   const roundup_bits = bits + (BITS_PER_BYTE - 1);
+
+//   return Math.floor(roundup_bits / BITS_PER_VARINT_BYTE);
+// }
+
+const varint_max = {
+  16: 3,
+  32: 5,
+  64: 10,
+  128: 19
+}
+function max_of_last_byte(type) {
+  let extra_bits = type % 7;
+  return (1 << extra_bits) - 1;
+}
+
+function de_varint(de, bits) {
+  let out = 0;
+
+  for (let i = 0; i < varint_max[bits]; i++) {
+    const val = de.pop();
+    const carry = val & 0x7F;
+    out |= carry << (7 * i);
+
+    if ((val & 0x80) === 0) {
+      if (i === varint_max[bits] - 1 && val > max_of_last_byte(bits)) {
+        throw new Error('deserialize bad variant')
+      } else {
+        return out
+      }
+    }
+  }
+
+  throw new Error('deserialize bad variant')
+}
+
+function de_varint_big(de, bits) {
+  let out = 0n;
+
+  for (let i = 0; i < varint_max[bits]; i++) {
+    const val = de.pop();
+    const carry = BigInt(val) & 0x7Fn;
+    out |= carry << (7n * BigInt(i));
+
+    if ((val & 0x80) === 0) {
+      if (i === varint_max[bits] - 1 && val > max_of_last_byte(bits)) {
+        throw new Error('deserialize bad variant')
+      } else {
+        return out
+      }
+    }
+  }
+
+  throw new Error('deserialize bad variant')
+}
+function deserializeU64(de) {
+  return de_varint_big(de, 64)
+}
+function deserializeString(de) {
+    const sz = deserializeU64(de);
+
+    let bytes = de.try_take_n(Number(sz));
+
+    return __text_decoder.decode(bytes);
+}
+const __text_decoder = new TextDecoder('utf-8');
+
+
+/**
+ * A function that returns a stream of strings 
+* @returns {Promise<string>} 
+*/
+export async function stringStream () {
+    const out = []
+    
+
+    return fetch('ipc://localhost/streams/string_stream', { method: "POST", body: Uint8Array.from(out), headers: { 'Content-Type': 'application/octet-stream' } })
+        .then(r => r.arrayBuffer())
+        .then(bytes => {
+            const de = new Deserializer(new Uint8Array(bytes))
+
+            return deserializeString(de)
+        })
+}
+

--- a/crates/gen-guest-rust/src/lib.rs
+++ b/crates/gen-guest-rust/src/lib.rs
@@ -74,9 +74,17 @@ impl RustWasm {
             .iter()
             .map(|(ident, _)| format_ident!("{}", ident));
 
-        quote! {
-            #sig {
-                ::tauri_bindgen_guest_rust::invoke(#mod_ident, #ident, &(#(#param_idents),*)).await.unwrap()
+        if func.streaming {
+            quote! {
+                #sig {
+                    ::tauri_bindgen_guest_rust::open_stream(#mod_ident, #ident, &(#(#param_idents),*)).await.unwrap()
+                }
+            }
+        } else {
+            quote! {
+                #sig {
+                    ::tauri_bindgen_guest_rust::invoke(#mod_ident, #ident, &(#(#param_idents),*)).await.unwrap()
+                }
             }
         }
     }
@@ -156,6 +164,12 @@ impl RustGenerator for RustWasm {
             impl #ident {
                 #(#functions)*
             }
+        }
+    }
+
+    fn print_streaming_result(&self, _: &Function, inner: TokenStream) -> TokenStream {
+        quote! {
+            ::tauri_bindgen_guest_rust::Streaming<#inner>
         }
     }
 }

--- a/crates/gen-guest-rust/tests/streams.rs
+++ b/crates/gen-guest-rust/tests/streams.rs
@@ -1,0 +1,12 @@
+#[allow(unused_imports, unused_variables, dead_code)]
+#[rustfmt::skip]
+pub mod streams {
+    use ::tauri_bindgen_guest_rust::serde;
+    use ::tauri_bindgen_guest_rust::bitflags;
+    ///A function that returns a stream of strings
+    pub async fn string_stream() -> ::tauri_bindgen_guest_rust::Streaming<String> {
+        ::tauri_bindgen_guest_rust::start_stream("streams", "string_stream", &())
+            .await
+            .unwrap()
+    }
+}

--- a/crates/gen-guest-ts/tests/streams.ts
+++ b/crates/gen-guest-ts/tests/streams.ts
@@ -1,0 +1,109 @@
+// @ts-nocheck
+class Deserializer {
+    source
+    offset
+    
+    constructor(bytes) {
+        this.source = bytes
+        this.offset = 0
+    }
+
+    pop() {
+        return this.source[this.offset++]
+    }
+
+    try_take_n(len) {
+        const out = this.source.slice(this.offset, this.offset + len)
+        this.offset += len
+        return out
+    }
+}
+// function varint_max(bits) {
+//   const BITS_PER_BYTE = 8;
+//   const BITS_PER_VARINT_BYTE = 7;
+
+//   const roundup_bits = bits + (BITS_PER_BYTE - 1);
+
+//   return Math.floor(roundup_bits / BITS_PER_VARINT_BYTE);
+// }
+
+const varint_max = {
+  16: 3,
+  32: 5,
+  64: 10,
+  128: 19
+}
+function max_of_last_byte(type) {
+  let extra_bits = type % 7;
+  return (1 << extra_bits) - 1;
+}
+
+function de_varint(de, bits) {
+  let out = 0;
+
+  for (let i = 0; i < varint_max[bits]; i++) {
+    const val = de.pop();
+    const carry = val & 0x7F;
+    out |= carry << (7 * i);
+
+    if ((val & 0x80) === 0) {
+      if (i === varint_max[bits] - 1 && val > max_of_last_byte(bits)) {
+        throw new Error('deserialize bad variant')
+      } else {
+        return out
+      }
+    }
+  }
+
+  throw new Error('deserialize bad variant')
+}
+
+function de_varint_big(de, bits) {
+  let out = 0n;
+
+  for (let i = 0; i < varint_max[bits]; i++) {
+    const val = de.pop();
+    const carry = BigInt(val) & 0x7Fn;
+    out |= carry << (7n * BigInt(i));
+
+    if ((val & 0x80) === 0) {
+      if (i === varint_max[bits] - 1 && val > max_of_last_byte(bits)) {
+        throw new Error('deserialize bad variant')
+      } else {
+        return out
+      }
+    }
+  }
+
+  throw new Error('deserialize bad variant')
+}
+function deserializeU64(de) {
+  return de_varint_big(de, 64)
+}
+function deserializeString(de) {
+    const sz = deserializeU64(de);
+
+    let bytes = de.try_take_n(Number(sz));
+
+    return __text_decoder.decode(bytes);
+}
+const __text_decoder = new TextDecoder('utf-8');
+
+
+
+/**
+ * A function that returns a stream of strings 
+*/
+export async function stringStream () : Promise<string> {
+    const out = []
+    
+
+    return fetch('ipc://localhost/streams/string_stream', { method: "POST", body: Uint8Array.from(out) })
+        .then(r => r.arrayBuffer())
+        .then(bytes => {
+            const de = new Deserializer(new Uint8Array(bytes))
+
+            return deserializeString(de)
+        }) as Promise<string>
+}
+        

--- a/crates/gen-host/tests/streams.rs
+++ b/crates/gen-host/tests/streams.rs
@@ -1,0 +1,35 @@
+#[allow(unused_imports, unused_variables, dead_code)]
+#[rustfmt::skip]
+pub mod streams {
+    use ::tauri_bindgen_host::serde;
+    use ::tauri_bindgen_host::bitflags;
+    pub trait Streams: Sized {
+        type StringStreamStream: ::tauri_bindgen_host::Stream<Item = String>
+            + Send
+            + 'static;
+        ///A function that returns a stream of strings
+        fn string_stream(&self) -> Self::StringStreamStream;
+    }
+    pub fn add_to_router<T, U>(
+        router: &mut ::tauri_bindgen_host::ipc_router_wip::Router<T>,
+        get_cx: impl Fn(&T) -> &U + Send + Sync + 'static,
+    ) -> Result<(), ::tauri_bindgen_host::ipc_router_wip::Error>
+    where
+        U: Streams + Send + Sync + 'static,
+    {
+        let wrapped_get_cx = ::std::sync::Arc::new(get_cx);
+        let get_cx = ::std::sync::Arc::clone(&wrapped_get_cx);
+        router
+            .func_wrap(
+                "streams",
+                "string_stream",
+                move |
+                    ctx: ::tauri_bindgen_host::ipc_router_wip::Caller<T>,
+                | -> ::tauri_bindgen_host::anyhow::Result<String> {
+                    let ctx = get_cx(ctx.data());
+                    Ok(ctx.string_stream())
+                },
+            )?;
+        Ok(())
+    }
+}

--- a/crates/gen-markdown/tests/streams.md
+++ b/crates/gen-markdown/tests/streams.md
@@ -1,0 +1,15 @@
+# streams
+
+
+
+## Type definitions
+
+
+
+## Functions
+
+### Function string_stream
+
+`func string_stream () -> string`
+
+A function that returns a stream of strings

--- a/crates/guest-rust/Cargo.toml
+++ b/crates/guest-rust/Cargo.toml
@@ -13,11 +13,13 @@ tauri-bindgen-guest-rust-macro = { path = "../guest-rust-macro" }
 wasm-bindgen-futures = "0.4.37"
 wasm-bindgen = "0.2.87"
 serde.workspace = true
-tracing = "0.1.37"
-postcard = { version = "1.0.7", features = ["alloc"]}
+tracing = { version = "0.1.37", features = ["log-always"] }
+postcard = { version = "1.0.7", features = ["alloc"] }
 heapless = "0.7.16"
 js-sys = "0.3.64"
 thiserror.workspace = true
+futures = "0.3.28"
+pin-project-lite = "0.2.13"
 
 [dependencies.web-sys]
 version = "0.3.64"
@@ -28,4 +30,6 @@ features = [
   'RequestMode',
   'Response',
   'Window',
+  'ReadableStream',
+  'ReadableStreamDefaultReader'
 ]

--- a/crates/guest-rust/src/lib.rs
+++ b/crates/guest-rust/src/lib.rs
@@ -2,11 +2,14 @@ pub use tauri_bindgen_guest_rust_macro::*;
 #[doc(hidden)]
 pub use {bitflags, serde, tracing};
 
+use futures::{ready, Future, Stream};
 use js_sys::Uint8Array;
+use pin_project_lite::pin_project;
 use serde::{de::DeserializeOwned, Serialize};
+use std::{marker::PhantomData, task::Poll};
 use wasm_bindgen::prelude::*;
 use wasm_bindgen_futures::JsFuture;
-use web_sys::{Request, RequestInit, RequestMode, Response};
+use web_sys::{ReadableStreamDefaultReader, Request, RequestInit, RequestMode, Response};
 
 #[derive(Debug, thiserror::Error)]
 pub enum Error {
@@ -62,4 +65,90 @@ where
     let body = Uint8Array::new(&body);
 
     Ok(postcard::from_bytes(&body.to_vec())?)
+}
+
+pub async fn open_stream<P, R>(module: &str, method: &str, val: &P) -> Result<Streaming<R>, Error>
+where
+    P: Serialize,
+    R: DeserializeOwned,
+{
+    let mut opts = RequestInit::new();
+    opts.method("POST");
+    opts.mode(RequestMode::Cors);
+
+    let bytes = postcard::to_allocvec(val)?;
+    let body = unsafe { Uint8Array::view(&bytes) };
+    opts.body(Some(&body));
+
+    let url = format!("ipc://localhost/{module}/{method}");
+
+    let request = Request::new_with_str_and_init(&url, &opts).map_err(Error::JsError)?;
+
+    request
+        .headers()
+        .set("Accept", "application/octet-stream")
+        .map_err(Error::JsError)?;
+
+    let window = web_sys::window().ok_or(Error::NoWindow)?;
+    let resp_value = JsFuture::from(window.fetch_with_request(&request))
+        .await
+        .map_err(Error::JsError)?;
+
+    // `resp_value` is a `Response` object.
+    assert!(resp_value.is_instance_of::<Response>());
+    let resp: Response = resp_value.dyn_into().map_err(Error::JsError)?;
+
+    let readable_stream = resp.body().unwrap();
+    let stream_reader = readable_stream.get_reader();
+
+    assert!(stream_reader.is_instance_of::<ReadableStreamDefaultReader>());
+    let stream_reader: ReadableStreamDefaultReader = stream_reader.dyn_into().unwrap();
+
+    Ok(Streaming {
+        future: JsFuture::from(stream_reader.read()),
+        stream_reader,
+        _m: PhantomData,
+    })
+}
+
+pin_project! {
+    pub struct Streaming<T> {
+        #[pin]
+        future: JsFuture,
+        stream_reader: ReadableStreamDefaultReader,
+        _m: PhantomData<T>,
+    }
+}
+
+impl<T: DeserializeOwned> Stream for Streaming<T> {
+    type Item = Result<T, Error>;
+
+    fn poll_next(
+        mut self: std::pin::Pin<&mut Self>,
+        cx: &mut std::task::Context<'_>,
+    ) -> std::task::Poll<Option<Self::Item>> {
+        let mut this = self.as_mut().project();
+
+        let v = ready!(this.future.as_mut().poll(cx)).unwrap();
+
+        let done = js_sys::Reflect::get(&v, &JsValue::from_str("done")).map_err(Error::JsError)?;
+        if done.is_truthy() {
+            return Poll::Ready(None);
+        } else {
+            let fut = JsFuture::from(this.stream_reader.read());
+            this.future.set(fut);
+        }
+
+        let value = {
+            let raw =
+                js_sys::Reflect::get(&v, &JsValue::from_str("value")).map_err(Error::JsError)?;
+
+            tracing::debug!("raw vaule from reader {raw:?}");
+
+            let raw = Uint8Array::new(&raw);
+            postcard::from_bytes(&raw.to_vec())?
+        };
+
+        return Poll::Ready(Some(Ok(value)));
+    }
 }

--- a/crates/host/Cargo.toml
+++ b/crates/host/Cargo.toml
@@ -11,9 +11,10 @@ rust-version.workspace = true
 bitflags.workspace = true
 tauri-bindgen-host-macro = { path = "../host-macro" }
 async-trait = "0.1.73"
-tauri = "1.4.1"
+tauri.workspace = true
 tracing = { version = "0.1.37", features = ["log", "log-always"] }
 anyhow = "1.0.75"
 serde.workspace = true
 ipc-router-wip = { path = "../ipc-router-wip" }
 generational-arena = "0.2.9"
+futures = "0.3.28"

--- a/crates/host/src/lib.rs
+++ b/crates/host/src/lib.rs
@@ -1,6 +1,6 @@
-pub use tauri_bindgen_host_macro::*;
-
+pub use futures::stream::Stream;
 pub use generational_arena::Arena as ResourceTable;
+pub use tauri_bindgen_host_macro::*;
 #[doc(hidden)]
 pub use {anyhow, async_trait::async_trait, bitflags, ipc_router_wip, serde, tauri, tracing};
 

--- a/crates/ipc-router-wip/Cargo.toml
+++ b/crates/ipc-router-wip/Cargo.toml
@@ -12,5 +12,4 @@ anyhow = "1.0.75"
 serde.workspace = true
 log.workspace = true
 postcard = { version = "1.0.7", features = ["alloc"] }
-tauri = "1.4.1"
-url = "2.4.1"
+tauri.workspace = true

--- a/crates/ipc-router-wip/src/lib.rs
+++ b/crates/ipc-router-wip/src/lib.rs
@@ -209,8 +209,8 @@ pub trait BuilderExt {
 impl<R: Runtime> BuilderExt for tauri::Builder<R> {
     fn ipc_router<U: Send + Sync + 'static>(self, router: Router<U>) -> Self {
         self.manage(Mutex::new(router))
-                let res = uri_scheme_handler_inner::<U, _>(app, req);
             .register_asynchronous_uri_scheme_protocol("ipc", |app, req, responder| {
+                let res = uri_scheme_handler_inner::<U, _>(app, req);
 
                 log::debug!("call result {:?}", res);
 

--- a/crates/wit-parser/src/lex.rs
+++ b/crates/wit-parser/src/lex.rs
@@ -137,6 +137,8 @@ pub enum Token {
     Interface,
     #[token("tuple")]
     Tuple,
+    #[token("stream")]
+    Stream,
 
     // reserved but currently unused
     #[token("use")]
@@ -160,7 +162,7 @@ impl Token {
         Token::Variant,
         Token::Resource,
     ];
-    pub const TYPE_KEYWORD: [Token; 20] = [
+    pub const TYPE_KEYWORD: [Token; 21] = [
         Token::U8,
         Token::U16,
         Token::U32,
@@ -181,6 +183,7 @@ impl Token {
         Token::List,
         Token::Tuple,
         Token::Ident,
+        Token::Stream,
     ];
     pub fn as_str(&self) -> &str {
         match self {
@@ -228,6 +231,7 @@ impl Token {
             Token::List => "'list'",
             Token::Interface => "'interface'",
             Token::Tuple => "'tuple'",
+            Token::Stream => "'stream'",
             Token::Use => "'use'",
             Token::As => "'as'",
             Token::From => "'from'",

--- a/crates/wit-parser/src/lib.rs
+++ b/crates/wit-parser/src/lib.rs
@@ -165,6 +165,7 @@ pub struct Function {
     pub ident: String,
     pub params: NamedTypeList,
     pub result: Option<FunctionResult>,
+    pub streaming: bool,
 }
 
 impl Function {

--- a/crates/wit-parser/src/typecheck.rs
+++ b/crates/wit-parser/src/typecheck.rs
@@ -294,6 +294,7 @@ impl<'a> Resolver<'a> {
             ident,
             params,
             result,
+            streaming: func.streaming,
         })
     }
 

--- a/examples/greet/Cargo.toml
+++ b/examples/greet/Cargo.toml
@@ -5,16 +5,18 @@ edition = "2021"
 
 # See more keys and their definitions at https://doc.rust-lang.org/cargo/reference/manifest.html
 [dependencies]
-serde-wasm-bindgen = "0.4.3"
-js-sys = "0.3.59" 
-serde = { version = "1.0.140", features = ["derive"] }
-wasm-bindgen = { version = "0.2.82", features = ["serde-serialize"] }
-wasm-bindgen-futures = "0.4.32"
+serde-wasm-bindgen = "0.4.5"
+js-sys = "0.3.64"
+serde = { version = "1.0.188", features = ["derive"] }
+wasm-bindgen = { version = "0.2.87", features = ["serde-serialize"] }
+wasm-bindgen-futures = "0.4.37"
 sycamore = { git = "https://github.com/sycamore-rs/sycamore", rev = "abd556cbc02047042dad2ebd04405e455a9b11b2", features = ["suspense", "hydrate"] }
 tauri-bindgen-guest-rust = { path = "../../crates/guest-rust" }
-log = "0.4.17"
-tracing-wasm = "0.2.1"
+log = "0.4.20"
+wasm-logger = "0.2.0"
+# tracing-wasm = "0.2.1"
 console_error_panic_hook = "0.1.7"
+futures-util = "0.3.28"
 
 [features]
 ssg = ["sycamore/ssr"]

--- a/examples/greet/greet2.wit
+++ b/examples/greet/greet2.wit
@@ -1,0 +1,3 @@
+interface greet {
+  func greet(my_name: string) -> stream<list<u8>>
+}

--- a/examples/greet/src-tauri/Cargo.toml
+++ b/examples/greet/src-tauri/Cargo.toml
@@ -16,11 +16,11 @@ tauri-build = { version = "1.1", features = [] }
 [dependencies]
 serde_json = "1.0"
 serde = { version = "1.0", features = ["derive"] }
-tauri = { version = "1.2.4", features = ["api-all"] }
+tauri = { git = "https://github.com/tauri-apps/tauri", features = [] }
 tauri-bindgen-host = { path = "../../../crates/host" }
-tracing-subscriber = "0.3.16"
+tracing-subscriber = "0.3.17"
 tracing = "0.1.37"
-anyhow = "1.0.71"
+anyhow = "1.0.75"
 
 [features]
 # by default Tauri runs in production mode

--- a/examples/greet/src-tauri/tauri.conf.json
+++ b/examples/greet/src-tauri/tauri.conf.json
@@ -1,4 +1,8 @@
 {
+  "package": {
+    "productName": "tauri-app",
+    "version": "0.0.0"
+  },
   "build": {
     "beforeDevCommand": "trunk serve",
     "beforeBuildCommand": "trunk build --release",
@@ -6,22 +10,11 @@
     "distDir": "../dist",
     "withGlobalTauri": true
   },
-  "package": {
-    "productName": "tauri-app",
-    "version": "0.0.0"
-  },
   "tauri": {
-    "allowlist": {
-      "all": true
-    },
     "bundle": {
       "active": true,
-      "category": "DeveloperTool",
-      "copyright": "",
-      "deb": {
-        "depends": []
-      },
-      "externalBin": [],
+      "targets": "all",
+      "identifier": "com.tauri.dev",
       "icon": [
         "icons/32x32.png",
         "icons/128x128.png",
@@ -29,38 +22,39 @@
         "icons/icon.icns",
         "icons/icon.ico"
       ],
-      "identifier": "com.tauri.dev",
-      "longDescription": "",
-      "macOS": {
-        "entitlements": null,
-        "exceptionDomain": "",
-        "frameworks": [],
-        "providerShortName": null,
-        "signingIdentity": null
-      },
       "resources": [],
+      "externalBin": [],
+      "copyright": "",
+      "category": "DeveloperTool",
       "shortDescription": "",
-      "targets": "all",
+      "longDescription": "",
+      "deb": {
+        "depends": []
+      },
+      "macOS": {
+        "frameworks": [],
+        "exceptionDomain": "",
+        "signingIdentity": null,
+        "providerShortName": null,
+        "entitlements": null
+      },
       "windows": {
         "certificateThumbprint": null,
         "digestAlgorithm": "sha256",
         "timestampUrl": ""
       }
     },
-    "security": {
-      "csp": null
-    },
-    "updater": {
-      "active": false
-    },
     "windows": [
       {
-        "fullscreen": false,
+        "title": "window",
+        "width": 800,
         "height": 600,
         "resizable": true,
-        "title": "tauri-app",
-        "width": 800
+        "fullscreen": false
       }
-    ]
+    ],
+    "security": {
+      "csp": null
+    }
   }
 }

--- a/examples/greet/src/app.rs
+++ b/examples/greet/src/app.rs
@@ -1,3 +1,4 @@
+use futures_util::stream::StreamExt;
 use sycamore::futures::spawn_local_scoped;
 use sycamore::prelude::*;
 
@@ -10,10 +11,20 @@ pub fn App<G: Html>(cx: Scope) -> View<G> {
     let name = create_signal(cx, String::new());
     let greet_msg = create_signal(cx, String::new());
 
+    spawn_local_scoped(cx, async move {
+        log::debug!("starting stream");
+
+        let mut stream = crate::greet2::greet::greet("world").await;
+
+        while let Some(msg) = stream.next().await {
+            log::debug!("got msg: {:?}", msg);
+        }
+    });
+
     let do_greet = move |_| {
         spawn_local_scoped(cx, async move {
             let new_msg = greet::greet(&name.get()).await;
- 
+
             greet_msg.set(new_msg);
         })
     };

--- a/examples/greet/src/greet2.rs
+++ b/examples/greet/src/greet2.rs
@@ -1,0 +1,9 @@
+#[allow(unused_imports, unused_variables, dead_code)]
+#[rustfmt::skip]
+pub mod greet {
+    use ::tauri_bindgen_guest_rust::serde;
+    use ::tauri_bindgen_guest_rust::bitflags;
+    pub async fn greet(my_name: &'_ str) -> ::tauri_bindgen_guest_rust::Streaming<Vec<u8>> {
+        ::tauri_bindgen_guest_rust::open_stream("greet", "greet", &(my_name)).await.unwrap()
+    }
+}

--- a/examples/greet/src/main.rs
+++ b/examples/greet/src/main.rs
@@ -1,4 +1,5 @@
 mod app;
+mod greet2;
 
 use app::App;
 
@@ -6,7 +7,8 @@ use app::App;
 fn main() {
     console_error_panic_hook::set_once();
 
-    tracing_wasm::set_as_global_default();
+    wasm_logger::init(wasm_logger::Config::default());
+    // tracing_wasm::set_as_global_default();
 
     sycamore::hydrate(App);
 }
@@ -15,7 +17,8 @@ fn main() {
 fn main() {
     console_error_panic_hook::set_once();
 
-    tracing_wasm::set_as_global_default();
+    wasm_logger::init(wasm_logger::Config::default());
+    // tracing_wasm::set_as_global_default();
 
     sycamore::render(App);
 }

--- a/playground/editor/src/wit.grammar
+++ b/playground/editor/src/wit.grammar
@@ -63,7 +63,9 @@ Function {
 
 FunctionResult {
   Type |
-  "(" commaSep<NamedType> ")"
+  "(" commaSep<NamedType> ")" |
+  "stream" "<" Type ">" |
+  "stream" "<" "(" commaSep<NamedType> ")" ">"
 }
 
 NamedType {
@@ -95,7 +97,7 @@ Type {
 @tokens {
   whitespace { $[ \t\n\f]+ }
 
-  LineComment { 
+  LineComment {
     "//" ![\n]* |
     "///" ![\n]*
   }
@@ -119,7 +121,7 @@ Type {
   "{" "}"
   "="
   "->" ":" "_" ","
-  "interface" "type" "record" "flags" "variant" "enum" "union" "resource" "func"
+  "interface" "type" "record" "flags" "variant" "enum" "union" "resource" "func" "stream"
 }
 
 @detectDelim

--- a/wit/streams.wit
+++ b/wit/streams.wit
@@ -1,0 +1,4 @@
+interface streams {
+  /// A function that returns a stream of strings
+  func string_stream() -> stream<string>
+}


### PR DESCRIPTION
This adds the initial implementation of streaming responses of functions aka the `stream` pseudo-type.

It's a pseudo to type because while it looks like any regular type: `stream<t>` the only valid position where it may appear is as the sole return type of a function like so

```rust
interface streams {
   func streaming_bytes() -> stream<list<u8>>
}
```

(This restriction might be gradually lifted at some point)

The primary motivation for this new addition is to model sequences of asynchronously produced data such as events, log streams, or just streaming bytes from e.g. the disk. 
With this addition the `tauri-bindgen` system can finally replace the current IPC system as this allows us to model events (in an IMO type-safer and more ergonomically way)

## Details

The generated guest rust code look like this:

```rust
pub async fn streaming_bytes() -> ::tauri_bindgen_guest_rust::Streaming<Vec<u8>>;
```

where `::tauri_bindgen_guest_rust::Streaming<T>` takes care of the underlying raw http stream and deserialisation of the incoming data. It in turn implements `Stream<Item = T>`. 
It's worth noting that currently the implementation relies on `ReadableStreams` returned by `fetch`, and so performs no additional buffering (everything follows the rust pull-based model here which is nice).

`Streaming<T>` doesn't implement framing yet though it probably should.

The generated host code looks like this:

```rust
pub trait Streams: Sized {
    type StreamingBytesStream: ::tauri_bindgen_host::Stream<Item = Vec<u8>>
        + Send
        + 'static;
    ///A function that returns a stream of strings
    fn streaming_bytes(&self) -> Self::StreamingBytesStream;
}
```

So an implementation would need to give a specific type for `StreamingBytesStream` (most likely some wrapper type)

```rust
struct Ctx {
   // a list of handles so we can send events to all open channels
   // this emulates a broadcast channel
   txs: Arc<Mutex<Vec<mpsc::Sender<Bytes>>>>
}


impl Streams for Ctx {
   type StreamingBytesStream = tokio_stream::wrappers::ReceiverStream<Bytes>;

   fn streaming_bytes(&self) -> Self::StreamingBytesStream {
      let (tx, rx) = mpsc::channel(250);

      // this can of course be refactored to not require locking
      let txs = self.txs.lock().unwrap();
      txs.push(tx);

      Self::StreamingBytesStream::new(rx)
   }
}
```

The above example also showcases how a similar DX to the classical tauri events can be achieved, by essentially passing around `mpsc::Sender` handles.

This closes #180 
