### PR TITLE
Improved CI setup

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -44,7 +44,7 @@ jobs:
           RUSTFLAGS: ${{matrix.rustflags}} ${{env.RUSTFLAGS}}
 
   msrv:
-    name: Rust 1.70.0
+    name: Rust MSRV
     needs: pre_ci
     if: needs.pre_ci.outputs.continue
     runs-on: ubuntu-latest
@@ -55,7 +55,9 @@ jobs:
         run: |
           sudo apt-get update
           sudo apt-get install -y webkit2gtk-4.0 libgtk-3-dev
-      - uses: dtolnay/rust-toolchain@1.70.0
+      - uses: dtolnay/rust-toolchain@stable
+        with:
+          toolchain: 1.70.0 # MSRV
       - uses: Swatinem/rust-cache@v2
       - run: cargo check --workspace --tests
 

--- a/.github/workflows/spelling.yml
+++ b/.github/workflows/spelling.yml
@@ -1,0 +1,21 @@
+name: Spelling
+
+permissions:
+  contents: read
+
+on: [pull_request]
+
+env:
+  RUST_BACKTRACE: 1
+  CARGO_TERM_COLOR: always
+  CLICOLOR: 1
+
+jobs:
+  spelling:
+    name: Spell Check with Typos
+    runs-on: ubuntu-latest
+    steps:
+    - name: Checkout Actions Repository
+      uses: actions/checkout@v3
+    - name: Spell Check Repo
+      uses: crate-ci/typos@master

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -3,7 +3,7 @@ name = "tauri-bindgen"
 authors.workspace = true
 version.workspace = true
 edition.workspace = true
-rust-version.workspace = true
+rust-version.workspace = true # MSRV
 
 [workspace]
 members = ["crates/*"]

--- a/README.md
+++ b/README.md
@@ -34,7 +34,7 @@ Here are a few reasons why that is cool:
 
 - **Compile-time Checks**
 
-When using strongly typed languages, such as Rust, TypeScript or ReScript the generated code will automatically ensure that you are calling the API correctly, as long as it passes the type checking youre golden. This is especially neat **when working in a team**, so your colleagues can't just change command signatures and pull the rug out from under you.
+When using strongly typed languages, such as Rust, TypeScript or ReScript the generated code will automatically ensure that you are calling the API correctly, as long as it passes the type checking your golden. This is especially neat **when working in a team**, so your colleagues can't just change command signatures and pull the rug out from under you.
 
 - **Easily auditable**
 

--- a/crates/wit-parser/src/error.rs
+++ b/crates/wit-parser/src/error.rs
@@ -76,7 +76,7 @@ pub enum Error {
         #[label("cannot be defined twice")]
         location: Span,
     },
-    /// Types can't recursively refer to themselves as that would make then possibly infinitly-sized.
+    /// Types can't recursively refer to themselves as that would make then possibly infinitely-sized.
     /// In Rust the compiler would force you to use heap indirection, however such a thing doesn't exist in out type system.
     ///
     /// This wouldn't be a problem with the current JSON format, but a custom binary one would have this limitation so for future proofing we deny recursive types.

--- a/docs/WIT.md
+++ b/docs/WIT.md
@@ -111,7 +111,7 @@ func greet(name: string) -> string
 At the top-level of each `wit` document lives the `interface` definition, file must contain exactly one such definition. 
 The name you give to an interface will dictate the name of the generated module and printed debug output.
 
-An interface may contain function declarations and type defintions. The order of declaration doesn't matter so you are free to define types after you have used them for example.
+An interface may contain function declarations and type definitions. The order of declaration doesn't matter so you are free to define types after you have used them for example.
 
 ```wit
 interface empty {}

--- a/renovate.json
+++ b/renovate.json
@@ -1,6 +1,0 @@
-{
-  "$schema": "https://docs.renovatebot.com/renovate-schema.json",
-  "extends": [
-    "config:base"
-  ]
-}

--- a/renovate.json5
+++ b/renovate.json5
@@ -1,0 +1,103 @@
+{
+  // schedule: [
+  //  'before 5am on the first day of the month',
+  //],
+  semanticCommits: 'enabled',
+  configMigration: true,
+  dependencyDashboard: true,
+  regexManagers: [
+    {
+      customType: 'regex',
+      fileMatch: [
+        '^rust-toolchain\\.toml$',
+        'Cargo.toml$',
+        'clippy.toml$',
+        '\\.clippy.toml$',
+        '^\\.github/workflows/ci.yml$',
+        '^\\.github/workflows/rust-next.yml$',
+      ],
+      matchStrings: [
+        'MSRV.*?(?<currentValue>\\d+\\.\\d+(\\.\\d+)?)',
+        '(?<currentValue>\\d+\\.\\d+(\\.\\d+)?).*?MSRV',
+      ],
+      depNameTemplate: 'rust',
+      packageNameTemplate: 'rust-lang/rust',
+      datasourceTemplate: 'github-releases',
+    },
+  ],
+  packageRules: [
+    {
+      commitMessageTopic: 'MSRV',
+      matchManagers: [
+        'regex',
+      ],
+      matchPackageNames: [
+        'rust',
+      ],
+      minimumReleaseAge: '252 days', // 6 releases * 6 weeks per release * 7 days per week
+      internalChecksFilter: 'strict',
+    },
+    // Goals:
+    // - Keep version reqs low, ignoring compatible normal/build dependencies
+    // - Take advantage of latest dev-dependencies
+    // - Rollup safe upgrades to reduce CI runner load
+    // - Help keep number of versions down by always using latest breaking change
+    // - Have lockfile and manifest in-sync
+    {
+      matchManagers: [
+        'cargo',
+      ],
+      matchDepTypes: [
+        'build-dependencies',
+        'dependencies',
+      ],
+      matchCurrentVersion: '>=0.1.0',
+      matchUpdateTypes: [
+        'patch',
+      ],
+      enabled: false,
+    },
+    {
+      matchManagers: [
+        'cargo',
+      ],
+      matchDepTypes: [
+        'build-dependencies',
+        'dependencies',
+      ],
+      matchCurrentVersion: '>=1.0.0',
+      matchUpdateTypes: [
+        'minor',
+      ],
+      enabled: false,
+    },
+    {
+      matchManagers: [
+        'cargo',
+      ],
+      matchDepTypes: [
+        'dev-dependencies',
+      ],
+      matchCurrentVersion: '>=0.1.0',
+      matchUpdateTypes: [
+        'patch',
+      ],
+      automerge: true,
+      groupName: 'compatible (dev)',
+    },
+    {
+      matchManagers: [
+        'cargo',
+      ],
+      matchDepTypes: [
+        'dev-dependencies',
+      ],
+      matchCurrentVersion: '>=1.0.0',
+      matchUpdateTypes: [
+        'minor',
+      ],
+      automerge: true,
+      groupName: 'compatible (dev)',
+    },
+  ],
+}

--- a/src/main.rs
+++ b/src/main.rs
@@ -29,7 +29,7 @@ struct Cli {
 
 #[derive(Debug, Parser)]
 enum Command {
-    /// Check a defintion file for errors.
+    /// Check a definition file for errors.
     Check {
         #[clap(flatten)]
         world: WorldOpt,

--- a/typos.toml
+++ b/typos.toml
@@ -1,0 +1,4 @@
+[default.extend-words]
+# Abbreviations
+inout = "inout"
+ser = "ser"


### PR DESCRIPTION
After talking to Ed Page yesterday, I decided to try out some maintainability improvements

This PR does the following:
- Dependency rollups instead of individual PRs (for dev-dependencies)
- Ignore compatible (minor & patch) regular & build deps (to keep version requirements as low as possible)
- Individual PRs for possibly incompatible (major) bumps
- Update the MSRV every 6 releases (So we support the last 6 releases)
- Add spellchecking