### PR TITLE
Feat: add `json` subcommand

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -74,7 +74,7 @@ jobs:
         with:
           components: clippy
       - uses: Swatinem/rust-cache@v2
-      - run: cargo clippy --workspace -- -Dclippy::all -Dclippy::pedantic
+      - run: cargo clippy --workspace --features unstable -- -Dclippy::all -Dclippy::pedantic
 
   rustfmt:
     name: Rustfmt

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -34,6 +34,7 @@ quote = "1.0.33"
 proc-macro2 = "1.0.67"
 syn = "2.0.33"
 schemars = "0.8.12"
+serde_json = "1.0"
 
 [dependencies]
 clap.workspace = true
@@ -48,10 +49,7 @@ miette.workspace = true
 env_logger = "0.10.0"
 log.workspace = true
 clap_complete = "4.4.1"
-serde_json = "1.0"
-
-[dev-dependencies]
-schemars = { version = "0.8.12", features = ["impl_json_schema"] }
+serde_json.workspace = true
 
 [features]
 unstable = ["dep:tauri-bindgen-gen-markdown"]

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -33,6 +33,7 @@ serde = "1.0.188"
 quote = "1.0.33"
 proc-macro2 = "1.0.67"
 syn = "2.0.33"
+schemars = "0.8.12"
 
 [dependencies]
 clap.workspace = true
@@ -47,6 +48,10 @@ miette.workspace = true
 env_logger = "0.10.0"
 log.workspace = true
 clap_complete = "4.4.1"
+serde_json = "1.0"
+
+[dev-dependencies]
+schemars = { version = "0.8.12", features = ["impl_json_schema"] }
 
 [features]
 unstable = ["dep:tauri-bindgen-gen-markdown"]

--- a/crates/gen-guest-js/src/lib.rs
+++ b/crates/gen-guest-js/src/lib.rs
@@ -48,8 +48,8 @@ pub struct JavaScript {
 impl JavaScript {
     fn print_function(&self, intf_name: &str, func: &Function) -> String {
         let docs = self.print_docs(func);
-        let ident = func.ident.to_lower_camel_case();
-        let name = func.ident.to_snake_case();
+        let ident = func.id.to_lower_camel_case();
+        let name = func.id.to_snake_case();
         let params = print_function_params(&func.params);
 
         let deserialize_result = func
@@ -91,7 +91,7 @@ export async function {ident} ({params}) {{
             .iter()
             .map(|func| {
                 let docs = self.print_docs(func);
-                let ident = func.ident.to_lower_camel_case();
+                let ident = func.id.to_lower_camel_case();
                 let params = print_function_params(&func.params);
 
                 format!(

--- a/crates/gen-guest-rust/src/lib.rs
+++ b/crates/gen-guest-rust/src/lib.rs
@@ -67,7 +67,7 @@ impl RustWasm {
             &BorrowMode::Owned,
         );
 
-        let ident = func.ident.to_snake_case();
+        let ident = func.id.to_snake_case();
 
         let param_idents = func
             .params

--- a/crates/gen-guest-rust/src/lib.rs
+++ b/crates/gen-guest-rust/src/lib.rs
@@ -157,7 +157,7 @@ impl RustGenerator for RustWasm {
             );
 
             let mod_ident = format!("{mod_ident}::resource::{}", ident.to_string().to_snake_case());
-            let ident = func.ident.to_snake_case();
+            let ident = func.id.to_snake_case();
 
             let param_idents = func
                 .params

--- a/crates/gen-guest-ts/src/lib.rs
+++ b/crates/gen-guest-ts/src/lib.rs
@@ -57,8 +57,8 @@ impl TypeScript {
     pub fn print_function(&self, intf_name: &str, func: &Function) -> String {
         let docs = print_docs(&func.docs);
 
-        let ident = func.ident.to_lower_camel_case();
-        let name = func.ident.to_snake_case();
+        let ident = func.id.to_lower_camel_case();
+        let name = func.id.to_snake_case();
 
         let params = self.print_function_params(&func.params);
 
@@ -204,7 +204,7 @@ export async function {ident} ({params}) : {result} {{
             .iter()
             .map(|field| {
                 let docs = print_docs(&field.docs);
-                let ident = field.ident.to_lower_camel_case();
+                let ident = field.id.to_lower_camel_case();
                 let ty = self.print_type(&field.ty);
 
                 format!("{docs}\n{ident}: {ty},\n")
@@ -220,7 +220,7 @@ export async function {ident} ({params}) : {result} {{
             .enumerate()
             .map(|(i, field)| {
                 let docs = print_docs(&field.docs);
-                let ident = field.ident.to_upper_camel_case();
+                let ident = field.id.to_upper_camel_case();
                 let value: u64 = 2 << i;
 
                 format!("{docs}\n{ident} = {value},\n")
@@ -236,7 +236,7 @@ export async function {ident} ({params}) : {result} {{
             .enumerate()
             .map(|(i, case)| {
                 let docs = print_docs(&case.docs);
-                let case_ident = case.ident.to_upper_camel_case();
+                let case_ident = case.id.to_upper_camel_case();
                 let value = case
                     .ty
                     .as_ref()
@@ -254,7 +254,7 @@ export async function {ident} ({params}) : {result} {{
             .iter()
             .map(|case| {
                 let docs = print_docs(&case.docs);
-                let case_ident = case.ident.to_upper_camel_case();
+                let case_ident = case.id.to_upper_camel_case();
 
                 format!("{docs}\n{ident}{case_ident}")
             })
@@ -269,7 +269,7 @@ export async function {ident} ({params}) : {result} {{
             .iter()
             .map(|case| {
                 let docs = print_docs(&case.docs);
-                let ident = case.ident.to_upper_camel_case();
+                let ident = case.id.to_upper_camel_case();
 
                 format!("{docs}\n{ident},\n")
             })
@@ -299,7 +299,7 @@ export async function {ident} ({params}) : {result} {{
             .map(|func| {
                 let docs = print_docs(&func.docs);
 
-                let ident = func.ident.to_lower_camel_case();
+                let ident = func.id.to_lower_camel_case();
 
                 let params = self.print_function_params(&func.params);
                 let result = func

--- a/crates/gen-host/src/lib.rs
+++ b/crates/gen-host/src/lib.rs
@@ -311,7 +311,7 @@ impl Host {
     }
 
     fn print_router_fn_definition(&self, mod_name: &str, func: &Function) -> TokenStream {
-        let func_name = func.ident.to_snake_case();
+        let func_name = func.id.to_snake_case();
         let func_ident = format_ident!("{}", func_name);
 
         let param_decl = match func.params.len() {
@@ -378,7 +378,7 @@ impl Host {
         resource_name: &str,
         method: &Function,
     ) -> TokenStream {
-        let func_name = method.ident.to_snake_case();
+        let func_name = method.id.to_snake_case();
         let func_ident = format_ident!("{}", func_name);
 
         let param_decl = method

--- a/crates/gen-host/src/lib.rs
+++ b/crates/gen-host/src/lib.rs
@@ -299,7 +299,7 @@ impl Host {
         let mod_name = mod_ident.to_snake_case();
 
         let functions = functions.map(|func| {
-            let func_name = func.ident.to_snake_case();
+            let func_name = func.id.to_snake_case();
             let func_ident = format_ident!("{}", func_name);
 
             let params = self.print_function_params(&func.params, &BorrowMode::Owned);

--- a/crates/gen-host/src/lib.rs
+++ b/crates/gen-host/src/lib.rs
@@ -360,7 +360,7 @@ impl Host {
         });
 
         let methods = methods.map(|(resource_name, method)| {
-            let func_name = method.ident.to_snake_case();
+            let func_name = method.id.to_snake_case();
             let func_ident = format_ident!("{}", func_name);
 
             let params = self.print_function_params(&method.params, &BorrowMode::Owned);

--- a/crates/gen-js/src/lib.rs
+++ b/crates/gen-js/src/lib.rs
@@ -135,7 +135,7 @@ pub trait JavaScriptGenerator {
         let fields = fields
             .iter()
             .map(|field| {
-                let ident = field.ident.to_lower_camel_case();
+                let ident = field.id.to_lower_camel_case();
 
                 format!("{ident}: {}", self.print_deserialize_ty(&field.ty))
             })
@@ -177,7 +177,7 @@ pub trait JavaScriptGenerator {
                     .as_ref()
                     .map_or("null".to_string(), |ty| self.print_deserialize_ty(ty));
 
-                let ident = case.ident.to_upper_camel_case();
+                let ident = case.id.to_upper_camel_case();
 
                 format!(
                     "case {tag}:
@@ -205,7 +205,7 @@ pub trait JavaScriptGenerator {
             .iter()
             .enumerate()
             .map(|(tag, case)| {
-                let ident = case.ident.to_upper_camel_case();
+                let ident = case.id.to_upper_camel_case();
                 format!(
                     "case {tag}:
     return \"{ident}\"
@@ -346,7 +346,7 @@ pub trait JavaScriptGenerator {
     fn print_serialize_record(&self, ident: &str, fields: &[RecordField]) -> String {
         let inner = fields
             .iter()
-            .map(|field| self.print_serialize_ty(&format!("val.{}", field.ident), &field.ty))
+            .map(|field| self.print_serialize_ty(&format!("val.{}", field.id), &field.ty))
             .collect::<Vec<_>>()
             .join(",\n");
 
@@ -378,7 +378,7 @@ pub trait JavaScriptGenerator {
             .iter()
             .enumerate()
             .map(|(tag, case)| {
-                let prop_access = format!("val.{}", case.ident.to_upper_camel_case());
+                let prop_access = format!("val.{}", case.id.to_upper_camel_case());
 
                 let inner = case.ty.as_ref().map_or(String::new(), |ty| {
                     self.print_serialize_ty(&prop_access, ty)
@@ -408,7 +408,7 @@ pub trait JavaScriptGenerator {
             .iter()
             .enumerate()
             .map(|(tag, case)| {
-                let ident = case.ident.to_upper_camel_case();
+                let ident = case.id.to_upper_camel_case();
                 format!(
                     "case \"{ident}\":
     serializeU32(out, {tag})

--- a/crates/gen-markdown/src/lib.rs
+++ b/crates/gen-markdown/src/lib.rs
@@ -88,7 +88,7 @@ impl Markdown {
                     .map(|field| {
                         format!(
                             "#### {ident}: `{ty}`\n{docs}\n",
-                            ident = field.ident,
+                            ident = field.id,
                             ty = self.print_ty(&field.ty),
                             docs = field.docs
                         )
@@ -103,7 +103,7 @@ impl Markdown {
                     .map(|field| {
                         format!(
                             "#### {ident}\n{docs}\n",
-                            ident = field.ident,
+                            ident = field.id,
                             docs = field.docs
                         )
                     })
@@ -117,7 +117,7 @@ impl Markdown {
                     .map(|case| {
                         format!(
                             "#### {ident}{ty}\n{docs}\n",
-                            ident = case.ident,
+                            ident = case.id,
                             ty = case
                                 .ty
                                 .as_ref()
@@ -134,11 +134,7 @@ impl Markdown {
                 let cases = cases
                     .iter()
                     .map(|case| {
-                        format!(
-                            "#### {ident}\n{docs}\n",
-                            ident = case.ident,
-                            docs = case.docs
-                        )
+                        format!("#### {ident}\n{docs}\n", ident = case.id, docs = case.docs)
                     })
                     .collect::<String>();
 
@@ -164,7 +160,7 @@ impl Markdown {
                     .map(|func| {
                         format!(
                             "### Method {ident}\n\n`func {ident} ({params}){result}`\n\n{docs}",
-                            ident = func.ident,
+                            ident = func.id,
                             params = self.print_named_types(&func.params),
                             result = func
                                 .result
@@ -184,7 +180,7 @@ impl Markdown {
     fn print_function(&self, func: &Function) -> String {
         format!(
             "### Function {ident}\n\n` func {ident} ({params}){result}`\n\n{docs}",
-            ident = func.ident,
+            ident = func.id,
             params = self.print_named_types(&func.params),
             result = func
                 .result

--- a/crates/gen-rust/src/lib.rs
+++ b/crates/gen-rust/src/lib.rs
@@ -223,7 +223,7 @@ pub trait RustGenerator {
         let borrow_attr = self
             .needs_borrow(&field.ty, mode)
             .then_some(quote! { #[serde(borrow)] });
-        let ident = format_ident!("{}", field.ident.to_snake_case());
+        let ident = format_ident!("{}", field.id.to_snake_case());
         let ty = self.print_ty(&field.ty, mode);
 
         quote! {
@@ -247,7 +247,7 @@ pub trait RustGenerator {
         let fields = fields
             .iter()
             .enumerate()
-            .map(|(i, FlagsField { docs, ident })| {
+            .map(|(i, FlagsField { docs, id: ident })| {
                 let docs = self.print_docs(docs);
                 let ident = format_ident!("{}", ident.TO_SHOUTY_SNEK_CASE());
                 let i = Literal::usize_unsuffixed(i);
@@ -294,7 +294,7 @@ pub trait RustGenerator {
 
     fn print_variant_case(&self, case: &VariantCase, mode: &BorrowMode) -> TokenStream {
         let docs = self.print_docs(&case.docs);
-        let ident = format_ident!("{}", case.ident.to_upper_camel_case());
+        let ident = format_ident!("{}", case.id.to_upper_camel_case());
 
         let payload = case.ty.as_ref().map(|ty| {
             let ty = self.print_ty(ty, mode);
@@ -331,7 +331,7 @@ pub trait RustGenerator {
 
     fn print_enum_case(&self, case: &EnumCase) -> TokenStream {
         let docs = self.print_docs(&case.docs);
-        let ident = format_ident!("{}", case.ident.to_upper_camel_case());
+        let ident = format_ident!("{}", case.id.to_upper_camel_case());
 
         quote! {
             #docs
@@ -382,7 +382,7 @@ pub trait RustGenerator {
         results_mode: &BorrowMode,
     ) -> TokenStream {
         let docs = self.print_docs(&sig.func.docs);
-        let ident = format_ident!("{}", sig.func.ident.to_snake_case());
+        let ident = format_ident!("{}", sig.func.id.to_snake_case());
 
         let pub_ = (!sig.private).then_some(quote! { pub });
         let unsafe_ = sig.unsafe_.then_some(quote! { unsafe });

--- a/crates/wit-parser/Cargo.toml
+++ b/crates/wit-parser/Cargo.toml
@@ -13,6 +13,8 @@ id-arena = "2.2.1"
 miette.workspace = true
 distance = "0.4.0"
 log.workspace = true
+serde = { workspace = true, features = ["derive"] }
+schemars.workspace = true
 
 [dev-dependencies]
 pretty_assertions = "1.4.0"

--- a/crates/wit-parser/Cargo.toml
+++ b/crates/wit-parser/Cargo.toml
@@ -18,3 +18,5 @@ schemars.workspace = true
 
 [dev-dependencies]
 pretty_assertions = "1.4.0"
+schemars = { version = "0.8.12", features = ["impl_json_schema"] }
+serde_json.workspace = true

--- a/crates/wit-parser/ast.json
+++ b/crates/wit-parser/ast.json
@@ -1,0 +1,999 @@
+{
+  "$schema": "http://json-schema.org/draft-07/schema#",
+  "title": "Interface",
+  "type": "object",
+  "required": [
+    "docs",
+    "functions",
+    "ident",
+    "typedefs"
+  ],
+  "properties": {
+    "docs": {
+      "type": "string"
+    },
+    "functions": {
+      "type": "array",
+      "items": {
+        "$ref": "#/definitions/Function"
+      }
+    },
+    "ident": {
+      "type": "string"
+    },
+    "typedefs": {
+      "type": "array",
+      "items": {
+        "$ref": "#/definitions/TypeDef"
+      }
+    }
+  },
+  "definitions": {
+    "EnumCase": {
+      "type": "object",
+      "required": [
+        "docs",
+        "id"
+      ],
+      "properties": {
+        "docs": {
+          "type": "string"
+        },
+        "id": {
+          "type": "string"
+        }
+      }
+    },
+    "FlagsField": {
+      "type": "object",
+      "required": [
+        "docs",
+        "id"
+      ],
+      "properties": {
+        "docs": {
+          "type": "string"
+        },
+        "id": {
+          "type": "string"
+        }
+      }
+    },
+    "Function": {
+      "type": "object",
+      "required": [
+        "docs",
+        "id",
+        "params"
+      ],
+      "properties": {
+        "docs": {
+          "type": "string"
+        },
+        "id": {
+          "type": "string"
+        },
+        "params": {
+          "type": "array",
+          "items": {
+            "$ref": "#/definitions/NamedType"
+          }
+        },
+        "result": {
+          "anyOf": [
+            {
+              "$ref": "#/definitions/FunctionResult"
+            },
+            {
+              "type": "null"
+            }
+          ]
+        }
+      }
+    },
+    "FunctionResult": {
+      "anyOf": [
+        {
+          "$ref": "#/definitions/Type"
+        },
+        {
+          "type": "array",
+          "items": {
+            "$ref": "#/definitions/NamedType"
+          }
+        }
+      ]
+    },
+    "NamedType": {
+      "type": "object",
+      "oneOf": [
+        {
+          "type": "object",
+          "required": [
+            "type"
+          ],
+          "properties": {
+            "type": {
+              "type": "string",
+              "enum": [
+                "bool"
+              ]
+            }
+          }
+        },
+        {
+          "type": "object",
+          "required": [
+            "type"
+          ],
+          "properties": {
+            "type": {
+              "type": "string",
+              "enum": [
+                "u8"
+              ]
+            }
+          }
+        },
+        {
+          "type": "object",
+          "required": [
+            "type"
+          ],
+          "properties": {
+            "type": {
+              "type": "string",
+              "enum": [
+                "u16"
+              ]
+            }
+          }
+        },
+        {
+          "type": "object",
+          "required": [
+            "type"
+          ],
+          "properties": {
+            "type": {
+              "type": "string",
+              "enum": [
+                "u32"
+              ]
+            }
+          }
+        },
+        {
+          "type": "object",
+          "required": [
+            "type"
+          ],
+          "properties": {
+            "type": {
+              "type": "string",
+              "enum": [
+                "u64"
+              ]
+            }
+          }
+        },
+        {
+          "type": "object",
+          "required": [
+            "type"
+          ],
+          "properties": {
+            "type": {
+              "type": "string",
+              "enum": [
+                "u128"
+              ]
+            }
+          }
+        },
+        {
+          "type": "object",
+          "required": [
+            "type"
+          ],
+          "properties": {
+            "type": {
+              "type": "string",
+              "enum": [
+                "s8"
+              ]
+            }
+          }
+        },
+        {
+          "type": "object",
+          "required": [
+            "type"
+          ],
+          "properties": {
+            "type": {
+              "type": "string",
+              "enum": [
+                "s16"
+              ]
+            }
+          }
+        },
+        {
+          "type": "object",
+          "required": [
+            "type"
+          ],
+          "properties": {
+            "type": {
+              "type": "string",
+              "enum": [
+                "s32"
+              ]
+            }
+          }
+        },
+        {
+          "type": "object",
+          "required": [
+            "type"
+          ],
+          "properties": {
+            "type": {
+              "type": "string",
+              "enum": [
+                "s64"
+              ]
+            }
+          }
+        },
+        {
+          "type": "object",
+          "required": [
+            "type"
+          ],
+          "properties": {
+            "type": {
+              "type": "string",
+              "enum": [
+                "s128"
+              ]
+            }
+          }
+        },
+        {
+          "type": "object",
+          "required": [
+            "type"
+          ],
+          "properties": {
+            "type": {
+              "type": "string",
+              "enum": [
+                "float32"
+              ]
+            }
+          }
+        },
+        {
+          "type": "object",
+          "required": [
+            "type"
+          ],
+          "properties": {
+            "type": {
+              "type": "string",
+              "enum": [
+                "float64"
+              ]
+            }
+          }
+        },
+        {
+          "type": "object",
+          "required": [
+            "type"
+          ],
+          "properties": {
+            "type": {
+              "type": "string",
+              "enum": [
+                "char"
+              ]
+            }
+          }
+        },
+        {
+          "type": "object",
+          "required": [
+            "type"
+          ],
+          "properties": {
+            "type": {
+              "type": "string",
+              "enum": [
+                "string"
+              ]
+            }
+          }
+        },
+        {
+          "type": "object",
+          "required": [
+            "type",
+            "value"
+          ],
+          "properties": {
+            "type": {
+              "type": "string",
+              "enum": [
+                "list"
+              ]
+            },
+            "value": {
+              "$ref": "#/definitions/Type"
+            }
+          }
+        },
+        {
+          "type": "object",
+          "required": [
+            "type",
+            "value"
+          ],
+          "properties": {
+            "type": {
+              "type": "string",
+              "enum": [
+                "tuple"
+              ]
+            },
+            "value": {
+              "type": "array",
+              "items": {
+                "$ref": "#/definitions/Type"
+              }
+            }
+          }
+        },
+        {
+          "type": "object",
+          "required": [
+            "type",
+            "value"
+          ],
+          "properties": {
+            "type": {
+              "type": "string",
+              "enum": [
+                "option"
+              ]
+            },
+            "value": {
+              "$ref": "#/definitions/Type"
+            }
+          }
+        },
+        {
+          "type": "object",
+          "required": [
+            "type",
+            "value"
+          ],
+          "properties": {
+            "type": {
+              "type": "string",
+              "enum": [
+                "result"
+              ]
+            },
+            "value": {
+              "type": "object",
+              "properties": {
+                "err": {
+                  "anyOf": [
+                    {
+                      "$ref": "#/definitions/Type"
+                    },
+                    {
+                      "type": "null"
+                    }
+                  ]
+                },
+                "ok": {
+                  "anyOf": [
+                    {
+                      "$ref": "#/definitions/Type"
+                    },
+                    {
+                      "type": "null"
+                    }
+                  ]
+                }
+              }
+            }
+          }
+        },
+        {
+          "type": "object",
+          "required": [
+            "type",
+            "value"
+          ],
+          "properties": {
+            "type": {
+              "type": "string",
+              "enum": [
+                "id"
+              ]
+            },
+            "value": {
+              "type": "integer",
+              "format": "uint32",
+              "minimum": 0.0
+            }
+          }
+        }
+      ],
+      "required": [
+        "id"
+      ],
+      "properties": {
+        "id": {
+          "type": "string"
+        }
+      }
+    },
+    "RecordField": {
+      "type": "object",
+      "required": [
+        "docs",
+        "id",
+        "ty"
+      ],
+      "properties": {
+        "docs": {
+          "type": "string"
+        },
+        "id": {
+          "type": "string"
+        },
+        "ty": {
+          "$ref": "#/definitions/Type"
+        }
+      }
+    },
+    "Type": {
+      "oneOf": [
+        {
+          "type": "object",
+          "required": [
+            "type"
+          ],
+          "properties": {
+            "type": {
+              "type": "string",
+              "enum": [
+                "bool"
+              ]
+            }
+          }
+        },
+        {
+          "type": "object",
+          "required": [
+            "type"
+          ],
+          "properties": {
+            "type": {
+              "type": "string",
+              "enum": [
+                "u8"
+              ]
+            }
+          }
+        },
+        {
+          "type": "object",
+          "required": [
+            "type"
+          ],
+          "properties": {
+            "type": {
+              "type": "string",
+              "enum": [
+                "u16"
+              ]
+            }
+          }
+        },
+        {
+          "type": "object",
+          "required": [
+            "type"
+          ],
+          "properties": {
+            "type": {
+              "type": "string",
+              "enum": [
+                "u32"
+              ]
+            }
+          }
+        },
+        {
+          "type": "object",
+          "required": [
+            "type"
+          ],
+          "properties": {
+            "type": {
+              "type": "string",
+              "enum": [
+                "u64"
+              ]
+            }
+          }
+        },
+        {
+          "type": "object",
+          "required": [
+            "type"
+          ],
+          "properties": {
+            "type": {
+              "type": "string",
+              "enum": [
+                "u128"
+              ]
+            }
+          }
+        },
+        {
+          "type": "object",
+          "required": [
+            "type"
+          ],
+          "properties": {
+            "type": {
+              "type": "string",
+              "enum": [
+                "s8"
+              ]
+            }
+          }
+        },
+        {
+          "type": "object",
+          "required": [
+            "type"
+          ],
+          "properties": {
+            "type": {
+              "type": "string",
+              "enum": [
+                "s16"
+              ]
+            }
+          }
+        },
+        {
+          "type": "object",
+          "required": [
+            "type"
+          ],
+          "properties": {
+            "type": {
+              "type": "string",
+              "enum": [
+                "s32"
+              ]
+            }
+          }
+        },
+        {
+          "type": "object",
+          "required": [
+            "type"
+          ],
+          "properties": {
+            "type": {
+              "type": "string",
+              "enum": [
+                "s64"
+              ]
+            }
+          }
+        },
+        {
+          "type": "object",
+          "required": [
+            "type"
+          ],
+          "properties": {
+            "type": {
+              "type": "string",
+              "enum": [
+                "s128"
+              ]
+            }
+          }
+        },
+        {
+          "type": "object",
+          "required": [
+            "type"
+          ],
+          "properties": {
+            "type": {
+              "type": "string",
+              "enum": [
+                "float32"
+              ]
+            }
+          }
+        },
+        {
+          "type": "object",
+          "required": [
+            "type"
+          ],
+          "properties": {
+            "type": {
+              "type": "string",
+              "enum": [
+                "float64"
+              ]
+            }
+          }
+        },
+        {
+          "type": "object",
+          "required": [
+            "type"
+          ],
+          "properties": {
+            "type": {
+              "type": "string",
+              "enum": [
+                "char"
+              ]
+            }
+          }
+        },
+        {
+          "type": "object",
+          "required": [
+            "type"
+          ],
+          "properties": {
+            "type": {
+              "type": "string",
+              "enum": [
+                "string"
+              ]
+            }
+          }
+        },
+        {
+          "type": "object",
+          "required": [
+            "type",
+            "value"
+          ],
+          "properties": {
+            "type": {
+              "type": "string",
+              "enum": [
+                "list"
+              ]
+            },
+            "value": {
+              "$ref": "#/definitions/Type"
+            }
+          }
+        },
+        {
+          "type": "object",
+          "required": [
+            "type",
+            "value"
+          ],
+          "properties": {
+            "type": {
+              "type": "string",
+              "enum": [
+                "tuple"
+              ]
+            },
+            "value": {
+              "type": "array",
+              "items": {
+                "$ref": "#/definitions/Type"
+              }
+            }
+          }
+        },
+        {
+          "type": "object",
+          "required": [
+            "type",
+            "value"
+          ],
+          "properties": {
+            "type": {
+              "type": "string",
+              "enum": [
+                "option"
+              ]
+            },
+            "value": {
+              "$ref": "#/definitions/Type"
+            }
+          }
+        },
+        {
+          "type": "object",
+          "required": [
+            "type",
+            "value"
+          ],
+          "properties": {
+            "type": {
+              "type": "string",
+              "enum": [
+                "result"
+              ]
+            },
+            "value": {
+              "type": "object",
+              "properties": {
+                "err": {
+                  "anyOf": [
+                    {
+                      "$ref": "#/definitions/Type"
+                    },
+                    {
+                      "type": "null"
+                    }
+                  ]
+                },
+                "ok": {
+                  "anyOf": [
+                    {
+                      "$ref": "#/definitions/Type"
+                    },
+                    {
+                      "type": "null"
+                    }
+                  ]
+                }
+              }
+            }
+          }
+        },
+        {
+          "type": "object",
+          "required": [
+            "type",
+            "value"
+          ],
+          "properties": {
+            "type": {
+              "type": "string",
+              "enum": [
+                "id"
+              ]
+            },
+            "value": {
+              "type": "integer",
+              "format": "uint32",
+              "minimum": 0.0
+            }
+          }
+        }
+      ]
+    },
+    "TypeDef": {
+      "type": "object",
+      "oneOf": [
+        {
+          "type": "object",
+          "required": [
+            "type",
+            "value"
+          ],
+          "properties": {
+            "type": {
+              "type": "string",
+              "enum": [
+                "alias"
+              ]
+            },
+            "value": {
+              "$ref": "#/definitions/Type"
+            }
+          }
+        },
+        {
+          "type": "object",
+          "required": [
+            "type",
+            "value"
+          ],
+          "properties": {
+            "type": {
+              "type": "string",
+              "enum": [
+                "record"
+              ]
+            },
+            "value": {
+              "type": "array",
+              "items": {
+                "$ref": "#/definitions/RecordField"
+              }
+            }
+          }
+        },
+        {
+          "type": "object",
+          "required": [
+            "type",
+            "value"
+          ],
+          "properties": {
+            "type": {
+              "type": "string",
+              "enum": [
+                "flags"
+              ]
+            },
+            "value": {
+              "type": "array",
+              "items": {
+                "$ref": "#/definitions/FlagsField"
+              }
+            }
+          }
+        },
+        {
+          "type": "object",
+          "required": [
+            "type",
+            "value"
+          ],
+          "properties": {
+            "type": {
+              "type": "string",
+              "enum": [
+                "variant"
+              ]
+            },
+            "value": {
+              "type": "array",
+              "items": {
+                "$ref": "#/definitions/VariantCase"
+              }
+            }
+          }
+        },
+        {
+          "type": "object",
+          "required": [
+            "type",
+            "value"
+          ],
+          "properties": {
+            "type": {
+              "type": "string",
+              "enum": [
+                "enum"
+              ]
+            },
+            "value": {
+              "type": "array",
+              "items": {
+                "$ref": "#/definitions/EnumCase"
+              }
+            }
+          }
+        },
+        {
+          "type": "object",
+          "required": [
+            "type",
+            "value"
+          ],
+          "properties": {
+            "type": {
+              "type": "string",
+              "enum": [
+                "union"
+              ]
+            },
+            "value": {
+              "type": "array",
+              "items": {
+                "$ref": "#/definitions/UnionCase"
+              }
+            }
+          }
+        },
+        {
+          "type": "object",
+          "required": [
+            "type",
+            "value"
+          ],
+          "properties": {
+            "type": {
+              "type": "string",
+              "enum": [
+                "resource"
+              ]
+            },
+            "value": {
+              "type": "array",
+              "items": {
+                "$ref": "#/definitions/Function"
+              }
+            }
+          }
+        }
+      ],
+      "required": [
+        "docs",
+        "ident"
+      ],
+      "properties": {
+        "docs": {
+          "type": "string"
+        },
+        "ident": {
+          "type": "string"
+        }
+      }
+    },
+    "UnionCase": {
+      "type": "object",
+      "required": [
+        "docs",
+        "ty"
+      ],
+      "properties": {
+        "docs": {
+          "type": "string"
+        },
+        "ty": {
+          "$ref": "#/definitions/Type"
+        }
+      }
+    },
+    "VariantCase": {
+      "type": "object",
+      "required": [
+        "docs",
+        "id"
+      ],
+      "properties": {
+        "docs": {
+          "type": "string"
+        },
+        "id": {
+          "type": "string"
+        },
+        "ty": {
+          "anyOf": [
+            {
+              "$ref": "#/definitions/Type"
+            },
+            {
+              "type": "null"
+            }
+          ]
+        }
+      }
+    }
+  }
+}

--- a/crates/wit-parser/src/typecheck.rs
+++ b/crates/wit-parser/src/typecheck.rs
@@ -101,7 +101,11 @@ impl<'a> Resolver<'a> {
                         let ident = self.resolve_ident(&field.ident).to_string();
                         let ty = self.resolve_type(&field.ty)?;
 
-                        Ok(RecordField { docs, ident, ty })
+                        Ok(RecordField {
+                            docs,
+                            id: ident,
+                            ty,
+                        })
                     })
                     .partition_result::<_, Error>()?;
 
@@ -112,7 +116,7 @@ impl<'a> Resolver<'a> {
                     let docs = self.resolve_docs(&field.docs);
                     let ident = self.resolve_ident(&field.ident).to_string();
 
-                    FlagsField { docs, ident }
+                    FlagsField { docs, id: ident }
                 });
 
                 TypeDefKind::Flags(fields.collect())
@@ -129,7 +133,11 @@ impl<'a> Resolver<'a> {
                             .map(|ty| self.resolve_type(ty))
                             .transpose()?;
 
-                        Ok(VariantCase { docs, ident, ty })
+                        Ok(VariantCase {
+                            docs,
+                            id: ident,
+                            ty,
+                        })
                     })
                     .partition_result::<_, Error>()?;
 
@@ -140,7 +148,7 @@ impl<'a> Resolver<'a> {
                     let docs = self.resolve_docs(&case.docs);
                     let ident = self.resolve_ident(&case.ident).to_string();
 
-                    EnumCase { docs, ident }
+                    EnumCase { docs, id: ident }
                 });
 
                 TypeDefKind::Enum(cases.collect())
@@ -291,7 +299,7 @@ impl<'a> Resolver<'a> {
 
         Ok(Function {
             docs,
-            ident,
+            id: ident,
             params,
             result,
         })

--- a/crates/wit-parser/tests/generate-json-schema.rs
+++ b/crates/wit-parser/tests/generate-json-schema.rs
@@ -1,0 +1,12 @@
+use schemars::schema_for;
+use wit_parser::*;
+
+#[test]
+fn main() -> Result<(), Box<dyn std::error::Error>> {
+    let schema = schema_for!(Interface);
+    let str = serde_json::to_string_pretty(&schema)?;
+
+    std::fs::write("ast.json", str)?;
+
+    Ok(())
+}

--- a/src/main.rs
+++ b/src/main.rs
@@ -51,7 +51,7 @@ enum Command {
     },
     #[cfg(feature = "unstable")]
     Json {
-        /// Wether to prettify the generated JSON.
+        /// Whether to prettify the generated JSON.
         #[clap(short, long)]
         pretty: bool,
         #[clap(flatten)]

--- a/src/main.rs
+++ b/src/main.rs
@@ -156,7 +156,7 @@ fn run() -> Result<()> {
         Command::Markdown { builder, world } => {
             let (path, contents) = gen_interface(builder, world)?;
 
-            write_file(&out_dir, &path, &contents)?;
+            write_file(out_dir, &path, &contents)?;
         }
         #[cfg(feature = "unstable")]
         Command::Json { world, pretty } => {
@@ -169,7 +169,7 @@ fn run() -> Result<()> {
 
             let iface = wit_parser::parse_and_resolve_file(&world.wit, |t| skipset.contains(t))?;
 
-            let mut stdout = std::io::stdout().lock();
+            let stdout = std::io::stdout().lock();
             if pretty {
                 serde_json::to_writer_pretty(stdout, &iface).into_diagnostic()?;
             } else {

--- a/src/main.rs
+++ b/src/main.rs
@@ -7,7 +7,6 @@ use clap::{ArgAction, Parser};
 use miette::{bail, IntoDiagnostic, Result, WrapErr};
 use std::{
     collections::HashSet,
-    io::Write,
     path::{Path, PathBuf},
     time::Instant,
 };


### PR DESCRIPTION
This adds the `json` subcommand behind the `--unstable` flag which can be used to dump the parsed and resolved AST in JSON format.

The JSON output can then be used for debugging or further code generation